### PR TITLE
fix(ci): use grep instead of tomllib for version extraction

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,13 +14,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@v4
-
       - name: Extract version from pyproject.toml
         id: version
         run: |
-          VERSION=$(uv run python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          VERSION=$(grep -m1 '^version' pyproject.toml | sed 's/.*"\(.*\)"/\1/')
           echo "version=v${VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Create tag and release


### PR DESCRIPTION
## Summary
- Replace `tomllib` (Python 3.11+) with `grep` for version extraction in release workflow
- Fixes release workflow failure on Python 3.10

## Test plan
- [x] `grep -m1 '^version' pyproject.toml | sed 's/.*"\(.*\)"/\1/'` outputs `1.0.0` locally
- [ ] Verify release workflow succeeds when release/v1.0.1 merges to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)