### PR TITLE
feat(rendering): show player labels next to scores

### DIFF
--- a/src/pika_zoo/env/pikachu_volleyball.py
+++ b/src/pika_zoo/env/pikachu_volleyball.py
@@ -49,6 +49,8 @@ class PikachuVolleyballEnv(ParallelEnv):
         random_mode: bool = False,
         p1_skin: str = "yellow",
         p2_skin: str = "yellow",
+        p1_label: str = "",
+        p2_label: str = "",
     ) -> None:
         super().__init__()
 
@@ -59,6 +61,8 @@ class PikachuVolleyballEnv(ParallelEnv):
         self.random_mode = random_mode
         self._p1_skin = p1_skin
         self._p2_skin = p2_skin
+        self._p1_label = p1_label
+        self._p2_label = p2_label
 
         self.possible_agents = ["player_1", "player_2"]
 
@@ -212,7 +216,11 @@ class PikachuVolleyballEnv(ParallelEnv):
             self._physics.player2,
             self._physics.ball,
             self._scores,
-            metadata={"mode": "random" if self.random_mode else "normal"},
+            metadata={
+                "mode": "random" if self.random_mode else "normal",
+                "p1_label": self._p1_label,
+                "p2_label": self._p2_label,
+            },
         )
 
     def close(self) -> None:

--- a/src/pika_zoo/rendering/renderer.py
+++ b/src/pika_zoo/rendering/renderer.py
@@ -97,6 +97,7 @@ class PygameRenderer:
         self._draw_player(player2)
         self._draw_ball(ball)
         self._draw_scores(scores)
+        self._draw_player_labels(metadata or {})
         self._draw_mode_label(metadata or {})
 
         # Draw overlays
@@ -244,6 +245,29 @@ class PygameRenderer:
         if scores[1] >= 10:
             self._screen.blit(numbers[1], (356, 10))
         self._screen.blit(numbers[scores[1] % 10], (388, 10))
+
+    # ------------------------------------------------------------------
+    # Player labels
+    # ------------------------------------------------------------------
+
+    def _draw_player_labels(self, metadata: dict[str, Any]) -> None:
+        """Draw player labels (model names) below scores."""
+        assert self._screen is not None
+        if self._mode_font is None:
+            pygame.font.init()
+            self._mode_font = pygame.font.SysFont("monospace", 14, bold=True)
+
+        p1_label = metadata.get("p1_label", "")
+        p2_label = metadata.get("p2_label", "")
+
+        if p1_label:
+            rendered = self._mode_font.render(p1_label, True, (0, 0, 0))
+            self._screen.blit(rendered, (14, 42))
+
+        if p2_label:
+            rendered = self._mode_font.render(p2_label, True, (0, 0, 0))
+            x = SCREEN_WIDTH - 14 - rendered.get_width()
+            self._screen.blit(rendered, (x, 42))
 
     # ------------------------------------------------------------------
     # Mode label

--- a/src/pika_zoo/scripts/play.py
+++ b/src/pika_zoo/scripts/play.py
@@ -79,6 +79,9 @@ def play(
     else:
         render_mode = None
 
+    p1_label = "human" if p1_human else p1
+    p2_label = "human" if p2_human else p2
+
     e = env(
         render_mode=render_mode,
         ai_policies=ai_policies,
@@ -86,12 +89,12 @@ def play(
         random_mode=random_mode,
         p1_skin=resolved_p1_skin,
         p2_skin=resolved_p2_skin,
+        p1_label=p1_label,
+        p2_label=p2_label,
     )
     e.reset(seed=seed)
 
     # Print match info
-    p1_label = "Human" if p1_human else p1
-    p2_label = "Human" if p2_human else p2
     print(f"Pikachu Volleyball — {p1_label} vs {p2_label} (first to {winning_score})")
     if p1_human:
         print("  P1: D(left) G(right) R(up) V(down) Z(power hit)")


### PR DESCRIPTION
## Summary
- Display player labels (model names) below score boards
- Labels auto-set from AI name or "human" in play command
- Configurable via `p1_label`/`p2_label` in env constructor

## Test plan
- [x] 74 tests passing
- [x] `uv run ruff check .` passes
- [x] Format check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)