### PR TITLE
refactor(env): replace random mode with noisy mode

### DIFF
--- a/src/pika_zoo/engine/physics.py
+++ b/src/pika_zoo/engine/physics.py
@@ -141,25 +141,24 @@ class Ball:
         self.initialize_for_new_round(is_player2_serve)
 
     def initialize_for_new_round(
-        self, is_player2_serve: bool, random_mode: bool = False, rng: Generator | None = None
+        self, is_player2_serve: bool, noisy: bool = False, rng: Generator | None = None
     ) -> None:
         """Reset ball state for a new round.
 
         Args:
             is_player2_serve: Which side serves.
-            random_mode: If True, ball starts at center with random velocity.
-            rng: Random generator (required if random_mode is True).
+            noisy: If True, add small noise to starting position and velocity.
+            rng: Random generator (required if noisy is True).
         """
-        if random_mode and rng is not None:
-            self.x = GROUND_HALF_WIDTH
-            self.y = 0
-            self.x_velocity = int(rng.integers(-20, 20))
-            self.y_velocity = int(rng.integers(-10, 0))
-        else:
-            self.x = 56 if not is_player2_serve else GROUND_WIDTH - 56
-            self.y = 0
-            self.x_velocity = 0
-            self.y_velocity = 1
+        self.x = 56 if not is_player2_serve else GROUND_WIDTH - 56
+        self.y = 0
+        self.x_velocity = 0
+        self.y_velocity = 1
+
+        if noisy and rng is not None:
+            self.x += int(rng.integers(-5, 6))  # ±5 pixels
+            self.x_velocity = int(rng.integers(-3, 4))  # small horizontal nudge
+
         self.punch_effect_radius: int = 0
         self.is_power_hit: bool = False
 

--- a/src/pika_zoo/env/pikachu_volleyball.py
+++ b/src/pika_zoo/env/pikachu_volleyball.py
@@ -46,7 +46,7 @@ class PikachuVolleyballEnv(ParallelEnv):
         serve: str = "winner",
         ai_policies: dict[str, AIPolicy] | None = None,
         render_mode: str | None = None,
-        random_mode: bool = False,
+        noisy: bool = False,
         p1_skin: str = "yellow",
         p2_skin: str = "yellow",
         p1_label: str = "",
@@ -58,7 +58,7 @@ class PikachuVolleyballEnv(ParallelEnv):
         self.serve = serve
         self.ai_policies = ai_policies or {}
         self.render_mode = render_mode
-        self.random_mode = random_mode
+        self.noisy = noisy
         self._p1_skin = p1_skin
         self._p2_skin = p2_skin
         self._p1_label = p1_label
@@ -96,9 +96,7 @@ class PikachuVolleyballEnv(ParallelEnv):
         self.agents = list(self.possible_agents)
 
         self._physics = PikaPhysics(self._np_random)
-        self._physics.ball.initialize_for_new_round(
-            self._is_player2_serve, random_mode=self.random_mode, rng=self._np_random
-        )
+        self._physics.ball.initialize_for_new_round(self._is_player2_serve, noisy=self.noisy, rng=self._np_random)
         self._scores = [0, 0]
         self._round_ended = False
         self._game_ended = False
@@ -130,9 +128,7 @@ class PikachuVolleyballEnv(ParallelEnv):
         if self._round_ended and not self._game_ended:
             self._physics.player1.initialize_for_new_round(self._np_random)
             self._physics.player2.initialize_for_new_round(self._np_random)
-            self._physics.ball.initialize_for_new_round(
-                self._is_player2_serve, random_mode=self.random_mode, rng=self._np_random
-            )
+            self._physics.ball.initialize_for_new_round(self._is_player2_serve, noisy=self.noisy, rng=self._np_random)
             self._round_ended = False
             for converter in self._action_converters.values():
                 converter.reset()
@@ -217,7 +213,7 @@ class PikachuVolleyballEnv(ParallelEnv):
             self._physics.ball,
             self._scores,
             metadata={
-                "mode": "random" if self.random_mode else "normal",
+                "mode": "noisy" if self.noisy else "normal",
                 "p1_label": self._p1_label,
                 "p2_label": self._p2_label,
             },

--- a/src/pika_zoo/rendering/renderer.py
+++ b/src/pika_zoo/rendering/renderer.py
@@ -274,7 +274,7 @@ class PygameRenderer:
     # ------------------------------------------------------------------
 
     def _draw_mode_label(self, metadata: dict[str, Any]) -> None:
-        """Draw mode label (normal/random) above the net."""
+        """Draw mode label (normal/noisy) at top center."""
         mode = metadata.get("mode")
         if not mode:
             return
@@ -282,7 +282,7 @@ class PygameRenderer:
         if self._mode_font is None:
             pygame.font.init()
             self._mode_font = pygame.font.SysFont("monospace", 14, bold=True)
-        color = (0, 0, 255) if mode == "random" else (0, 0, 0)
+        color = (0, 0, 255) if mode == "noisy" else (0, 0, 0)
         rendered = self._mode_font.render(mode, True, color)
         x = SCREEN_WIDTH // 2 - rendered.get_width() // 2
         self._screen.blit(rendered, (x, 10))

--- a/src/pika_zoo/scripts/play.py
+++ b/src/pika_zoo/scripts/play.py
@@ -31,7 +31,7 @@ def play(
     fps: int = 25,
     render: bool = True,
     record: str | None = None,
-    random_mode: bool = False,
+    noisy: bool = False,
     p1_skin: str | None = None,
     p2_skin: str | None = None,
 ) -> None:
@@ -45,7 +45,7 @@ def play(
         fps: Frame rate (for render and/or recording).
         render: Show pygame window.
         record: Output MP4 path, or None to skip recording.
-        random_mode: Randomize ball starting position/velocity each round.
+        noisy: Add small noise to ball starting position/velocity each round.
         p1_skin: Pikachu skin for P1 (default: auto from AI registry, "yellow" for human).
         p2_skin: Pikachu skin for P2 (default: auto from AI registry, "yellow" for human).
     """
@@ -86,7 +86,7 @@ def play(
         render_mode=render_mode,
         ai_policies=ai_policies,
         winning_score=winning_score,
-        random_mode=random_mode,
+        noisy=noisy,
         p1_skin=resolved_p1_skin,
         p2_skin=resolved_p2_skin,
         p1_label=p1_label,
@@ -194,7 +194,7 @@ def main(argv: list[str] | None = None) -> None:
     parser.add_argument("--fps", type=int, default=25, help="Frames per second (default: 25)")
     parser.add_argument("--no-render", action="store_true", help="Disable pygame window (headless)")
     parser.add_argument("--record", type=str, default=None, metavar="FILE", help="Record to MP4 (requires ffmpeg)")
-    parser.add_argument("--random", action="store_true", help="Random ball start position/velocity each round")
+    parser.add_argument("--noisy", action="store_true", help="Add noise to ball start position/velocity")
     parser.add_argument("--p1-skin", type=str, default=None, help="P1 pikachu skin (default: auto from AI)")
     parser.add_argument("--p2-skin", type=str, default=None, help="P2 pikachu skin (default: auto from AI)")
     args = parser.parse_args(argv)
@@ -207,7 +207,7 @@ def main(argv: list[str] | None = None) -> None:
         fps=args.fps,
         render=not args.no_render,
         record=args.record,
-        random_mode=args.random,
+        noisy=args.noisy,
         p1_skin=args.p1_skin,
         p2_skin=args.p2_skin,
     )


### PR DESCRIPTION
## Summary
Replace random mode (center start, wild velocity) with noisy mode that preserves game mechanics:
- Serve position maintained (winner serves) with ±5px noise
- Small x_velocity perturbation [-3, 3] to prevent pattern memorization
- Renamed: `random_mode` → `noisy`, `--random` → `--noisy`

## Why
- Random mode stripped serve advantage (a game mechanic reward)
- Wild velocities made even builtin AI struggle unrealistically
- Noisy mode balances generalization with faithful game dynamics

## Test plan
- [x] 74 tests passing
- [x] `uv run ruff check .` + format passes
- [x] `uv run play --noisy --winning-score 3` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)