### PR TITLE
feat(ai): add RandomAI baseline with lime skin

### DIFF
--- a/src/pika_zoo/ai/__init__.py
+++ b/src/pika_zoo/ai/__init__.py
@@ -1,10 +1,12 @@
 from pika_zoo.ai.builtin import BuiltinAI
 from pika_zoo.ai.protocol import AIPolicy
+from pika_zoo.ai.random import RandomAI
 from pika_zoo.ai.registry import get_ai, get_skin, register_ai
 
 __all__ = [
     "AIPolicy",
     "BuiltinAI",
+    "RandomAI",
     "get_ai",
     "get_skin",
     "register_ai",

--- a/src/pika_zoo/ai/random.py
+++ b/src/pika_zoo/ai/random.py
@@ -1,0 +1,32 @@
+"""
+Random AI — takes completely random actions every frame.
+
+Useful as a baseline opponent for training and evaluation.
+"""
+
+from __future__ import annotations
+
+from numpy.random import Generator
+
+from pika_zoo.engine.physics import Ball, Player
+from pika_zoo.engine.types import UserInput
+
+
+class RandomAI:
+    """AI that picks random x_direction, y_direction, and power_hit each frame."""
+
+    def compute_action(
+        self,
+        player: Player,
+        ball: Ball,
+        opponent: Player,
+        rng: Generator,
+    ) -> UserInput:
+        user_input = UserInput()
+        user_input.x_direction = int(rng.integers(-1, 2))  # -1, 0, 1
+        user_input.y_direction = int(rng.integers(-1, 2))
+        user_input.power_hit = int(rng.integers(0, 2))  # 0 or 1
+        return user_input
+
+    def reset(self, rng: Generator) -> None:
+        pass

--- a/src/pika_zoo/ai/registry.py
+++ b/src/pika_zoo/ai/registry.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from pika_zoo.ai.builtin import BuiltinAI
+from pika_zoo.ai.random import RandomAI
 
 DEFAULT_SKIN = "lime"
 
@@ -52,3 +53,4 @@ def get_skin(name: str) -> str:
 
 # Auto-register builtins
 register_ai("builtin", BuiltinAI, skin="orange")
+register_ai("random", RandomAI, skin="lime")


### PR DESCRIPTION
## Summary
- Add `RandomAI` — random actions every frame, baseline for training/eval
- Registered as `"random"` with lime skin
- `uv run play --p1 builtin --p2 random` to watch builtin destroy it

🤖 Generated with [Claude Code](https://claude.com/claude-code)