### PR TITLE
feat(record): add server field to RoundRecord

### DIFF
--- a/src/pika_zoo/wrappers/record_episode.py
+++ b/src/pika_zoo/wrappers/record_episode.py
@@ -40,7 +40,8 @@ class RoundRecord:
     """Record of a single round (one point scored)."""
 
     round_number: int
-    scorer: str  # "player_1" or "player_2"
+    server: str  # "player_1" or "player_2" — who served this round
+    scorer: str  # "player_1" or "player_2" — who scored
     reward: dict[str, float]
     start_frame: int
     end_frame: int
@@ -83,6 +84,7 @@ class EpisodeRecord:
             "rounds": [
                 {
                     "round_number": r.round_number,
+                    "server": r.server,
                     "scorer": r.scorer,
                     "reward": r.reward,
                     "start_frame": r.start_frame,
@@ -111,6 +113,7 @@ class RecordEpisode(BaseParallelWrapper):
         self._round_start_frame: int = 1
         self._prev_scores: list[int] = [0, 0]
         self._current_round_frames: list[FrameSnapshot] = []
+        self._current_server: str = "player_1"
 
     def reset(self, seed=None, options=None):
         observations, infos = super().reset(seed=seed, options=options)
@@ -119,6 +122,8 @@ class RecordEpisode(BaseParallelWrapper):
         self._round_start_frame = 1
         self._prev_scores = [0, 0]
         self._current_round_frames = []
+        # First round server: check env's _is_player2_serve
+        self._current_server = "player_2" if self.env._is_player2_serve else "player_1"
         return observations, infos
 
     def step(self, actions):
@@ -173,6 +178,7 @@ class RecordEpisode(BaseParallelWrapper):
             self._current_episode.rounds.append(
                 RoundRecord(
                     round_number=round_number,
+                    server=self._current_server,
                     scorer=scorer,
                     reward=reward,
                     start_frame=self._round_start_frame,
@@ -183,6 +189,8 @@ class RecordEpisode(BaseParallelWrapper):
             self._current_round_frames = []
             self._round_start_frame = self._frame_count + 1
             self._prev_scores = current_scores
+            # Next round server: the scorer serves (env uses "winner" serve by default)
+            self._current_server = "player_2" if self.env._is_player2_serve else "player_1"
 
         # 5. Add episode stats to infos on game end
         if any(terminations.values()):

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -237,9 +237,10 @@ class TestRecordEpisode:
         assert record is not None
         # Total rounds should match total score
         assert len(record.rounds) == sum(record.scores)
-        # Each round should have a valid scorer
+        # Each round should have a valid scorer and server
         for r in record.rounds:
             assert r.scorer in ("player_1", "player_2")
+            assert r.server in ("player_1", "player_2")
             assert r.start_frame <= r.end_frame
         # Round numbers should be sequential
         for i, r in enumerate(record.rounds):
@@ -294,6 +295,22 @@ class TestRecordEpisode:
             assert record.winner == "player_1"
         else:
             assert record.winner == "player_2"
+
+    def test_server_tracking(self):
+        """First round server should be player_1, then scorer serves next."""
+        e = env(winning_score=3)
+        wrapped = RecordEpisode(e)
+        wrapped.reset(seed=42)
+        for _ in range(5000):
+            obs, rewards, terms, _, _ = wrapped.step({"player_1": 0, "player_2": 0})
+            if any(terms.values()):
+                break
+        record = wrapped.get_episode_record()
+        # First round: player_1 serves (default)
+        assert record.rounds[0].server == "player_1"
+        # Subsequent rounds: scorer of previous round serves
+        for i in range(1, len(record.rounds)):
+            assert record.rounds[i].server == record.rounds[i - 1].scorer
 
     def test_round_duration(self):
         e = env(winning_score=2)


### PR DESCRIPTION
## Summary
Add `server` field to `RoundRecord` — tracks who served each round.

Enables serve win rate analysis in training-center without manual tracking.

Closes #23

## Usage
```python
for r in record.rounds:
    print(f"R{r.round_number}: {r.server} served → {r.scorer} scored")

serve_wins = sum(1 for r in record.rounds if r.server == r.scorer)
```

## Test plan
- [x] 75 tests passing (1 new server tracking test)
- [x] `uv run ruff check .` passes
- [x] First round server = player_1, subsequent = previous scorer

🤖 Generated with [Claude Code](https://claude.com/claude-code)