### PR TITLE
fix(ai): remap SB3ModelPolicy actions and normalize obs

### DIFF
--- a/src/pika_zoo/ai/sb3_adapter.py
+++ b/src/pika_zoo/ai/sb3_adapter.py
@@ -8,11 +8,19 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import numpy as np
 from numpy.random import Generator
 
 from pika_zoo.engine.physics import Ball, Player
 from pika_zoo.engine.types import UserInput
 from pika_zoo.env.actions import ACTION_TABLE
+from pika_zoo.wrappers.normalize_observation import OBS_LOW, OBS_RANGE
+from pika_zoo.wrappers.simplify_action import P1_MAP, P2_MAP
+
+_SIMPLIFIED_MAPS: dict[str, list[int]] = {
+    "player_1": P1_MAP,
+    "player_2": P2_MAP,
+}
 
 
 class SB3ModelPolicy:
@@ -25,9 +33,25 @@ class SB3ModelPolicy:
     Args:
         model_path: Path to saved SB3 model (.zip).
         deterministic: Use deterministic predictions (default True).
+        simplified: If True, treat model output as simplified 13-action indices
+            and remap through the per-player SimplifyAction table (default True).
+        normalized: If True, normalize raw observations to [0, 1] before prediction
+            using the same min-max scaling as NormalizeObservation (default True).
+        agent: Agent name ("player_1" or "player_2"). Required when simplified=True.
     """
 
-    def __init__(self, model_path: str | Path, deterministic: bool = True) -> None:
+    def __init__(
+        self,
+        model_path: str | Path,
+        deterministic: bool = True,
+        simplified: bool = True,
+        normalized: bool = True,
+        agent: str | None = None,
+    ) -> None:
+        if simplified and agent is None:
+            raise ValueError("agent must be specified when simplified=True")
+        if simplified and agent not in _SIMPLIFIED_MAPS:
+            raise ValueError(f"Unknown agent: {agent!r}. Must be 'player_1' or 'player_2'.")
         try:
             from stable_baselines3 import PPO
         except ImportError:
@@ -37,6 +61,8 @@ class SB3ModelPolicy:
 
         self._model = PPO.load(str(model_path), device="cpu")
         self._deterministic = deterministic
+        self._normalized = normalized
+        self._action_map: list[int] | None = _SIMPLIFIED_MAPS.get(agent) if simplified else None
         self._last_obs = None
 
     def set_observation(self, obs) -> None:
@@ -54,8 +80,16 @@ class SB3ModelPolicy:
         if self._last_obs is None:
             return UserInput()
 
-        action, _ = self._model.predict(self._last_obs, deterministic=self._deterministic)
+        obs = self._last_obs
+        if self._normalized:
+            obs = np.clip((obs - OBS_LOW) / OBS_RANGE, 0.0, 1.0).astype(np.float32)
+
+        action, _ = self._model.predict(obs, deterministic=self._deterministic)
         action_idx = int(action)
+
+        # Remap simplified (13) action to raw (18) action if needed
+        if self._action_map is not None:
+            action_idx = self._action_map[action_idx]
 
         # Convert action index to UserInput
         keys = ACTION_TABLE[action_idx]

--- a/src/pika_zoo/scripts/play.py
+++ b/src/pika_zoo/scripts/play.py
@@ -76,7 +76,7 @@ def play(
         if Path(spec).exists():
             from pika_zoo.ai.sb3_adapter import SB3ModelPolicy
 
-            policy = SB3ModelPolicy(spec)
+            policy = SB3ModelPolicy(spec, agent=agent)
             ai_policies[agent] = policy
             sb3_policies[agent] = policy
         else:

--- a/src/pika_zoo/wrappers/simplify_action.py
+++ b/src/pika_zoo/wrappers/simplify_action.py
@@ -34,7 +34,7 @@ NUM_SIMPLIFIED_ACTIONS: int = 13
 
 # Player 1 (left side): toward_net = RIGHT, away = LEFT
 # fmt: off
-_P1_MAP: list[int] = [
+P1_MAP: list[int] = [
     0,   # NOOP
     1,   # FIRE
     2,   # UP
@@ -51,7 +51,7 @@ _P1_MAP: list[int] = [
 ]
 
 # Player 2 (right side): toward_net = LEFT, away = RIGHT
-_P2_MAP: list[int] = [
+P2_MAP: list[int] = [
     0,   # NOOP
     1,   # FIRE
     2,   # UP
@@ -75,8 +75,8 @@ class SimplifyAction(BaseParallelWrapper):
     def __init__(self, env):
         super().__init__(env)
         self._maps = {
-            "player_1": np.array(_P1_MAP, dtype=np.int32),
-            "player_2": np.array(_P2_MAP, dtype=np.int32),
+            "player_1": np.array(P1_MAP, dtype=np.int32),
+            "player_2": np.array(P2_MAP, dtype=np.int32),
         }
 
     def action_space(self, agent: str) -> spaces.Discrete:


### PR DESCRIPTION
## Summary
- `SB3ModelPolicy`가 `SimplifyAction`으로 학습된 모델의 13개 relative action을 플레이어별 매핑 테이블로 변환하도록 수정
- raw observation을 `NormalizeObservation`과 동일한 min-max 정규화 적용 후 모델에 전달
- `simplified`, `normalized`, `agent` 파라미터 추가 (기본값 True)

Closes #29

## Test plan
- [x] `uv run pytest` 75개 전체 통과
- [x] 과적합 모델로 builtin 상대 5-0 승리 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)