### PR TITLE
feat(wrappers): add SimplifyObservation for x-axis mirroring

### DIFF
--- a/src/pika_zoo/wrappers/__init__.py
+++ b/src/pika_zoo/wrappers/__init__.py
@@ -3,6 +3,7 @@ from pika_zoo.wrappers.normalize_observation import NormalizeObservation
 from pika_zoo.wrappers.record_episode import EpisodeRecord, FrameSnapshot, RecordEpisode, RoundRecord
 from pika_zoo.wrappers.reward_shaping import RewardShaping
 from pika_zoo.wrappers.simplify_action import SimplifyAction
+from pika_zoo.wrappers.simplify_observation import SimplifyObservation
 
 __all__ = [
     "ConvertSingleAgent",
@@ -13,4 +14,5 @@ __all__ = [
     "RecordEpisode",
     "RewardShaping",
     "SimplifyAction",
+    "SimplifyObservation",
 ]

--- a/src/pika_zoo/wrappers/simplify_observation.py
+++ b/src/pika_zoo/wrappers/simplify_observation.py
@@ -1,0 +1,52 @@
+"""
+Wrapper that mirrors x-axis observations for player_2.
+
+Both players' observations are already agent-centric (self first, opponent second),
+but x-coordinates are absolute. Player 1 is on the left (x near 0), player 2 on
+the right (x near 432). This wrapper mirrors player_2's x-axis so both players
+see themselves as "on the left side of the court."
+
+Player_1 observations pass through unchanged.
+
+Must be applied BEFORE NormalizeObservation in the wrapper chain — mirroring
+operates on raw coordinates, normalization maps them to [0, 1] afterward.
+
+Mirrored features (player_2 only):
+  Positions (432 - x):  self.x, opponent.x, ball.x, ball.prev_x, ball.prev_prev_x
+  Directions (negate):  self.diving_direction, opponent.diving_direction, ball.x_velocity
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from pettingzoo.utils import BaseParallelWrapper
+
+from pika_zoo.engine.constants import GROUND_WIDTH
+
+# Indices where x-position must be mirrored (GROUND_WIDTH - x)
+_POSITION_INDICES = np.array([0, 13, 26, 28, 30], dtype=np.intp)
+
+# Indices where x-direction/velocity must be negated
+_DIRECTION_INDICES = np.array([3, 16, 32], dtype=np.intp)
+
+
+class SimplifyObservation(BaseParallelWrapper):
+    """Mirror player_2 x-axis observations so both players see the left-side perspective."""
+
+    def reset(self, seed=None, options=None):
+        observations, infos = super().reset(seed=seed, options=options)
+        observations["player_2"] = _mirror(observations["player_2"])
+        return observations, infos
+
+    def step(self, actions):
+        observations, rewards, terminations, truncations, infos = super().step(actions)
+        observations["player_2"] = _mirror(observations["player_2"])
+        return observations, rewards, terminations, truncations, infos
+
+
+def _mirror(obs: np.ndarray) -> np.ndarray:
+    """Mirror x-axis values so player sees themselves on the left side."""
+    mirrored = obs.copy()
+    mirrored[_POSITION_INDICES] = GROUND_WIDTH - mirrored[_POSITION_INDICES]
+    mirrored[_DIRECTION_INDICES] = -mirrored[_DIRECTION_INDICES]
+    return mirrored

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -14,6 +14,7 @@ from pika_zoo.wrappers import (
     RecordEpisode,
     RewardShaping,
     SimplifyAction,
+    SimplifyObservation,
 )
 from pika_zoo.wrappers.simplify_action import NUM_SIMPLIFIED_ACTIONS
 
@@ -114,6 +115,86 @@ class TestSimplifyAction:
     def test_full_game(self):
         e = env(winning_score=2)
         wrapped = SimplifyAction(e)
+        wrapped.reset(seed=42)
+        game_ended = False
+        for _ in range(3000):
+            actions = {"player_1": 0, "player_2": 0}
+            obs, rewards, terms, truncs, infos = wrapped.step(actions)
+            if any(terms.values()):
+                game_ended = True
+                break
+        assert game_ended
+
+
+class TestSimplifyObservation:
+    def test_player1_unchanged(self):
+        """Player 1 observations should pass through unmodified."""
+        raw_env = env()
+        raw_obs, _ = raw_env.reset(seed=42)
+
+        wrapped_env = env()
+        wrapped = SimplifyObservation(wrapped_env)
+        wrapped_obs, _ = wrapped.reset(seed=42)
+
+        np.testing.assert_array_equal(wrapped_obs["player_1"], raw_obs["player_1"])
+
+    def test_player2_x_mirrored(self):
+        """Player 2 x-positions should be mirrored (432 - x)."""
+        raw_env = env()
+        raw_obs, _ = raw_env.reset(seed=42)
+
+        wrapped_env = env()
+        wrapped = SimplifyObservation(wrapped_env)
+        wrapped_obs, _ = wrapped.reset(seed=42)
+
+        assert wrapped_obs["player_2"][0] == pytest.approx(432.0 - raw_obs["player_2"][0])
+        assert wrapped_obs["player_2"][13] == pytest.approx(432.0 - raw_obs["player_2"][13])
+        assert wrapped_obs["player_2"][26] == pytest.approx(432.0 - raw_obs["player_2"][26])
+
+    def test_player2_direction_negated(self):
+        """Player 2 x-direction/velocity should be negated."""
+        raw_env = env()
+        raw_obs, _ = raw_env.reset(seed=42)
+
+        wrapped_env = env()
+        wrapped = SimplifyObservation(wrapped_env)
+        wrapped_obs, _ = wrapped.reset(seed=42)
+
+        assert wrapped_obs["player_2"][3] == pytest.approx(-raw_obs["player_2"][3])
+        assert wrapped_obs["player_2"][32] == pytest.approx(-raw_obs["player_2"][32])
+
+    def test_step_mirrors_player2(self):
+        """Mirroring should also apply to step() observations."""
+        raw_env = env()
+        raw_env.reset(seed=42)
+        raw_obs, _, _, _, _ = raw_env.step({"player_1": 0, "player_2": 0})
+
+        wrapped_env = env()
+        wrapped = SimplifyObservation(wrapped_env)
+        wrapped.reset(seed=42)
+        wrapped_obs, _, _, _, _ = wrapped.step({"player_1": 0, "player_2": 0})
+
+        assert wrapped_obs["player_2"][0] == pytest.approx(432.0 - raw_obs["player_2"][0])
+        assert wrapped_obs["player_2"][26] == pytest.approx(432.0 - raw_obs["player_2"][26])
+
+    def test_obs_shape_preserved(self):
+        e = env()
+        wrapped = SimplifyObservation(e)
+        obs, _ = wrapped.reset(seed=42)
+        for agent_obs in obs.values():
+            assert agent_obs.shape == (OBSERVATION_SIZE,)
+            assert agent_obs.dtype == np.float32
+
+    def test_symmetric_initial_positions(self):
+        """After mirroring, both players should see similar self.x at start."""
+        e = env()
+        wrapped = SimplifyObservation(e)
+        obs, _ = wrapped.reset(seed=42)
+        assert obs["player_1"][0] == pytest.approx(obs["player_2"][0])
+
+    def test_full_game(self):
+        e = env(winning_score=2)
+        wrapped = SimplifyObservation(e)
         wrapped.reset(seed=42)
         game_ended = False
         for _ in range(3000):


### PR DESCRIPTION
## Summary
- `SimplifyObservation` 래퍼 추가: player_2의 x좌표를 미러링하여 양쪽 플레이어가 동일한 시점(좌측)에서 관측
- 위치(432-x): self.x, opponent.x, ball.x/prev_x/prev_prev_x
- 방향/속도(부호 반전): self.diving_direction, opponent.diving_direction, ball.x_velocity
- player_1은 패스스루, 사용 여부는 소비자(training-center)가 결정
- `NormalizeObservation` 전에 적용해야 함

## Test plan
- [x] player_1 패스스루 확인
- [x] player_2 x좌표 미러링 확인 (reset + step)
- [x] 초기 위치 대칭 확인 (양쪽 self.x ≈ 36)
- [x] full game 완주 확인
- [x] 35 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)