### PR TITLE
feat(ai): SB3ModelPolicy observation_simplified support

### DIFF
--- a/src/pika_zoo/ai/README.md
+++ b/src/pika_zoo/ai/README.md
@@ -29,16 +29,20 @@ Adapter that wraps an SB3 model (PPO, etc.) as an `AIPolicy`. Used by the `play`
 ```python
 SB3ModelPolicy(
     model_path="model.zip",
-    agent="player_1",       # required: determines action/observation mapping
-    simplified=True,        # remap 13 simplified actions → 18 raw actions
-    normalized=True,        # normalize observations before prediction
+    agent="player_1",              # required: determines action/observation mapping
+    action_simplified=True,        # remap 13 simplified actions → 18 raw actions
+    observation_simplified=False,  # mirror player_2 x-axis (SimplifyObservation)
+    observation_normalized=True,   # normalize observations to [0, 1]
 )
 ```
 
-- `simplified=True`: remaps model output (0–12) through the per-player `SimplifyAction` mapping table to raw actions (0–17)
-- `normalized=True`: applies the same min-max scaling as `NormalizeObservation` before passing observations to the model
+| Parameter | Default | Corresponding Wrapper |
+|-----------|---------|----------------------|
+| `action_simplified` | `True` | `SimplifyAction` — remap model output (0–12) to raw actions (0–17) |
+| `observation_simplified` | `False` | `SimplifyObservation` — mirror player_2 x-axis (only applied for player_2) |
+| `observation_normalized` | `True` | `NormalizeObservation` — min-max scale to [0, 1] |
 
-Both default to `True` since the standard training pipeline uses `SimplifyAction` + `NormalizeObservation` wrappers.
+Processing order: simplify → normalize (same as wrapper stacking order).
 
 ## Registry
 

--- a/src/pika_zoo/ai/sb3_adapter.py
+++ b/src/pika_zoo/ai/sb3_adapter.py
@@ -16,6 +16,7 @@ from pika_zoo.engine.types import UserInput
 from pika_zoo.env.actions import ACTION_TABLE
 from pika_zoo.wrappers.normalize_observation import OBS_LOW, OBS_RANGE
 from pika_zoo.wrappers.simplify_action import P1_MAP, P2_MAP
+from pika_zoo.wrappers.simplify_observation import _mirror
 
 _SIMPLIFIED_MAPS: dict[str, list[int]] = {
     "player_1": P1_MAP,
@@ -26,31 +27,35 @@ _SIMPLIFIED_MAPS: dict[str, list[int]] = {
 class SB3ModelPolicy:
     """Wraps an SB3 model (PPO, etc.) as an AIPolicy.
 
-    The model receives a simplified observation and returns a discrete action.
+    The model receives a processed observation and returns a discrete action.
     This adapter converts between the engine's Player/Ball state and the
     model's expected observation format.
 
     Args:
         model_path: Path to saved SB3 model (.zip).
         deterministic: Use deterministic predictions (default True).
-        simplified: If True, treat model output as simplified 13-action indices
-            and remap through the per-player SimplifyAction table (default True).
-        normalized: If True, normalize raw observations to [0, 1] before prediction
+        action_simplified: If True, treat model output as simplified 13-action
+            indices and remap through the per-player SimplifyAction table (default True).
+        observation_simplified: If True, mirror player_2's x-axis observations
+            using the same transform as SimplifyObservation (default False).
+        observation_normalized: If True, normalize raw observations to [0, 1]
             using the same min-max scaling as NormalizeObservation (default True).
-        agent: Agent name ("player_1" or "player_2"). Required when simplified=True.
+        agent: Agent name ("player_1" or "player_2").
+            Required when action_simplified=True or observation_simplified=True.
     """
 
     def __init__(
         self,
         model_path: str | Path,
         deterministic: bool = True,
-        simplified: bool = True,
-        normalized: bool = True,
+        action_simplified: bool = True,
+        observation_simplified: bool = False,
+        observation_normalized: bool = True,
         agent: str | None = None,
     ) -> None:
-        if simplified and agent is None:
-            raise ValueError("agent must be specified when simplified=True")
-        if simplified and agent not in _SIMPLIFIED_MAPS:
+        if (action_simplified or observation_simplified) and agent is None:
+            raise ValueError("agent must be specified when action_simplified=True or observation_simplified=True")
+        if action_simplified and agent not in _SIMPLIFIED_MAPS:
             raise ValueError(f"Unknown agent: {agent!r}. Must be 'player_1' or 'player_2'.")
         try:
             from stable_baselines3 import PPO
@@ -61,8 +66,9 @@ class SB3ModelPolicy:
 
         self._model = PPO.load(str(model_path), device="cpu")
         self._deterministic = deterministic
-        self._normalized = normalized
-        self._action_map: list[int] | None = _SIMPLIFIED_MAPS.get(agent) if simplified else None
+        self._observation_simplified = observation_simplified and agent == "player_2"
+        self._observation_normalized = observation_normalized
+        self._action_map: list[int] | None = _SIMPLIFIED_MAPS.get(agent) if action_simplified else None
         self._last_obs = None
 
     def set_observation(self, obs) -> None:
@@ -81,7 +87,9 @@ class SB3ModelPolicy:
             return UserInput()
 
         obs = self._last_obs
-        if self._normalized:
+        if self._observation_simplified:
+            obs = _mirror(obs)
+        if self._observation_normalized:
             obs = np.clip((obs - OBS_LOW) / OBS_RANGE, 0.0, 1.0).astype(np.float32)
 
         action, _ = self._model.predict(obs, deterministic=self._deterministic)


### PR DESCRIPTION
## Summary
- `SB3ModelPolicy` 파라미터 이름 변경: `simplified` → `action_simplified`, `normalized` → `observation_normalized`
- `observation_simplified` 추가: player_2의 x-axis 미러링 (SimplifyObservation과 동일)
- 처리 순서: simplify → normalize (래퍼 스택 순서와 동일)
- ai/README.md 문서 업데이트

Closes #37

## Test plan
- [x] `uv run pytest` — 82 tests passing
- [x] 기본값 유지로 기존 동작 호환 (`action_simplified=True`, `observation_normalized=True`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)