### PR TITLE
refactor(wrappers): unify game terminology (RecordEpisode → RecordGame)

### DIFF
--- a/src/pika_zoo/wrappers/README.md
+++ b/src/pika_zoo/wrappers/README.md
@@ -83,9 +83,9 @@ Opponent can be:
 - Callable `(obs → action)` — called each step
 - `None` — random actions
 
-## RecordEpisode
+## RecordGame
 
-Records per-frame game state snapshots and per-round scoring records. Exports to JSON via `get_episode_record().to_dict()`.
+Records per-frame game state snapshots and per-round scoring records. Exports to JSON via `get_game_record().to_dict()`.
 
 Records include: frame-by-frame positions/states, round boundaries, server/scorer tracking, and episode statistics.
 
@@ -98,4 +98,4 @@ Records include: frame-by-frame positions/states, round boundaries, server/score
 | `normalize_observation.py` | Min-max normalization to [0, 1] |
 | `reward_shaping.py` | Ball position + normal state rewards |
 | `convert_single_agent.py` | ParallelEnv → Gymnasium for SB3 |
-| `record_episode.py` | Per-round frame recording + JSON export |
+| `record_game.py` | Per-round frame recording + JSON export |

--- a/src/pika_zoo/wrappers/__init__.py
+++ b/src/pika_zoo/wrappers/__init__.py
@@ -1,18 +1,18 @@
 from pika_zoo.wrappers.convert_single_agent import ConvertSingleAgent
 from pika_zoo.wrappers.normalize_observation import NormalizeObservation
-from pika_zoo.wrappers.record_episode import EpisodeRecord, FrameSnapshot, RecordEpisode, RoundRecord
+from pika_zoo.wrappers.record_game import FrameSnapshot, GameRecord, RecordGame, RoundRecord
 from pika_zoo.wrappers.reward_shaping import RewardShaping
 from pika_zoo.wrappers.simplify_action import SimplifyAction
 from pika_zoo.wrappers.simplify_observation import SimplifyObservation
 
 __all__ = [
     "ConvertSingleAgent",
-    "EpisodeRecord",
     "FrameSnapshot",
+    "GameRecord",
     "NormalizeObservation",
-    "RoundRecord",
-    "RecordEpisode",
+    "RecordGame",
     "RewardShaping",
+    "RoundRecord",
     "SimplifyAction",
     "SimplifyObservation",
 ]

--- a/src/pika_zoo/wrappers/record_game.py
+++ b/src/pika_zoo/wrappers/record_game.py
@@ -1,8 +1,8 @@
 """
-Wrapper that records episode statistics and per-frame game state for replay.
+Wrapper that records game statistics and per-frame state for replay.
 
 Records:
-- Episode length and cumulative rewards (in infos)
+- Game length and cumulative rewards (in infos, under "episode" key for SB3 compatibility)
 - Per-round scoring records with frames grouped by round
 - Per-frame game state snapshots for later JSON export
 """
@@ -53,8 +53,8 @@ class RoundRecord:
 
 
 @dataclass
-class EpisodeRecord:
-    """Complete record of an episode (full game)."""
+class GameRecord:
+    """Complete record of a game (all rounds up to winning_score)."""
 
     scores: list[int] = field(default_factory=lambda: [0, 0])
     total_frames: int = 0
@@ -72,7 +72,7 @@ class EpisodeRecord:
 
     @property
     def frames(self) -> list[FrameSnapshot]:
-        """Flat list of all frames across all rounds (backward compatible)."""
+        """Flat list of all frames across all rounds."""
         return [f for r in self.rounds for f in r.frames]
 
     def to_dict(self) -> dict[str, Any]:
@@ -96,8 +96,8 @@ class EpisodeRecord:
         }
 
 
-class RecordEpisode(BaseParallelWrapper):
-    """Record episode statistics and game state snapshots.
+class RecordGame(BaseParallelWrapper):
+    """Record game statistics and state snapshots.
 
     Args:
         env: The base PikachuVolleyballEnv.
@@ -108,7 +108,7 @@ class RecordEpisode(BaseParallelWrapper):
     def __init__(self, env, record_frames: bool = True) -> None:
         super().__init__(env)
         self._record_frames = record_frames
-        self._current_episode: EpisodeRecord | None = None
+        self._current_game: GameRecord | None = None
         self._frame_count: int = 0
         self._round_start_frame: int = 1
         self._prev_scores: list[int] = [0, 0]
@@ -117,7 +117,7 @@ class RecordEpisode(BaseParallelWrapper):
 
     def reset(self, seed=None, options=None):
         observations, infos = super().reset(seed=seed, options=options)
-        self._current_episode = EpisodeRecord()
+        self._current_game = GameRecord()
         self._frame_count = 0
         self._round_start_frame = 1
         self._prev_scores = [0, 0]
@@ -131,16 +131,16 @@ class RecordEpisode(BaseParallelWrapper):
         p2_action = actions.get("player_2", 0)
         observations, rewards, terminations, truncations, infos = super().step(actions)
 
-        if self._current_episode is None:
+        if self._current_game is None:
             return observations, rewards, terminations, truncations, infos
 
         # 1. Increment frame count
         self._frame_count += 1
-        self._current_episode.total_frames = self._frame_count
+        self._current_game.total_frames = self._frame_count
 
         # 2. Update cumulative rewards
-        self._current_episode.cumulative_rewards["player_1"] += rewards.get("player_1", 0.0)
-        self._current_episode.cumulative_rewards["player_2"] += rewards.get("player_2", 0.0)
+        self._current_game.cumulative_rewards["player_1"] += rewards.get("player_1", 0.0)
+        self._current_game.cumulative_rewards["player_2"] += rewards.get("player_2", 0.0)
 
         # 3. Record frame snapshot into current round buffer (BEFORE round detection)
         physics = self.env._physics
@@ -167,7 +167,7 @@ class RecordEpisode(BaseParallelWrapper):
         # 4. Detect round end by score change
         current_scores = list(self.env._scores)
         if current_scores != self._prev_scores:
-            round_number = len(self._current_episode.rounds) + 1
+            round_number = len(self._current_game.rounds) + 1
             if current_scores[0] > self._prev_scores[0]:
                 scorer = "player_1"
                 reward = {"player_1": 1.0, "player_2": -1.0}
@@ -175,7 +175,7 @@ class RecordEpisode(BaseParallelWrapper):
                 scorer = "player_2"
                 reward = {"player_1": -1.0, "player_2": 1.0}
 
-            self._current_episode.rounds.append(
+            self._current_game.rounds.append(
                 RoundRecord(
                     round_number=round_number,
                     server=self._current_server,
@@ -192,19 +192,20 @@ class RecordEpisode(BaseParallelWrapper):
             # Next round server: the scorer serves (env uses "winner" serve by default)
             self._current_server = "player_2" if self.env._is_player2_serve else "player_1"
 
-        # 5. Add episode stats to infos on game end
+        # 5. Add game stats to infos on game end
+        # NOTE: uses "episode" key for SB3/Gymnasium compatibility
         if any(terminations.values()):
-            self._current_episode.scores = current_scores
+            self._current_game.scores = current_scores
             for agent in infos:
                 infos[agent]["episode"] = {
-                    "length": self._current_episode.total_frames,
-                    "rewards": dict(self._current_episode.cumulative_rewards),
-                    "scores": list(self._current_episode.scores),
-                    "winner": self._current_episode.winner,
+                    "length": self._current_game.total_frames,
+                    "rewards": dict(self._current_game.cumulative_rewards),
+                    "scores": list(self._current_game.scores),
+                    "winner": self._current_game.winner,
                 }
 
         return observations, rewards, terminations, truncations, infos
 
-    def get_episode_record(self) -> EpisodeRecord | None:
-        """Return the current episode record (call after episode ends)."""
-        return self._current_episode
+    def get_game_record(self) -> GameRecord | None:
+        """Return the current game record (call after game ends)."""
+        return self._current_game

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -11,7 +11,7 @@ from pika_zoo.env.observations import OBSERVATION_SIZE
 from pika_zoo.wrappers import (
     ConvertSingleAgent,
     NormalizeObservation,
-    RecordEpisode,
+    RecordGame,
     RewardShaping,
     SimplifyAction,
     SimplifyObservation,
@@ -265,23 +265,23 @@ class TestRewardShaping:
             assert rewards["player_2"] == 0.0
 
 
-class TestRecordEpisode:
+class TestRecordGame:
     def test_records_frames(self):
         e = env(winning_score=1)
-        wrapped = RecordEpisode(e)
+        wrapped = RecordGame(e)
         wrapped.reset(seed=42)
         for _ in range(300):
             obs, rewards, terms, _, _ = wrapped.step({"player_1": 0, "player_2": 0})
             if any(terms.values()):
                 break
-        record = wrapped.get_episode_record()
+        record = wrapped.get_game_record()
         assert record is not None
         assert record.total_frames > 0
         assert len(record.frames) == record.total_frames
 
     def test_episode_stats_in_info(self):
         e = env(winning_score=1)
-        wrapped = RecordEpisode(e)
+        wrapped = RecordGame(e)
         wrapped.reset(seed=42)
         for _ in range(300):
             obs, rewards, terms, _, infos = wrapped.step({"player_1": 0, "player_2": 0})
@@ -294,13 +294,13 @@ class TestRecordEpisode:
 
     def test_to_dict_serializable(self):
         e = env(winning_score=1)
-        wrapped = RecordEpisode(e)
+        wrapped = RecordGame(e)
         wrapped.reset(seed=42)
         for _ in range(300):
             obs, rewards, terms, _, _ = wrapped.step({"player_1": 0, "player_2": 0})
             if any(terms.values()):
                 break
-        record = wrapped.get_episode_record()
+        record = wrapped.get_game_record()
         d = record.to_dict()
         # Should be JSON-serializable
         json_str = json.dumps(d)
@@ -308,13 +308,13 @@ class TestRecordEpisode:
 
     def test_round_records(self):
         e = env(winning_score=3)
-        wrapped = RecordEpisode(e)
+        wrapped = RecordGame(e)
         wrapped.reset(seed=42)
         for _ in range(5000):
             obs, rewards, terms, _, _ = wrapped.step({"player_1": 0, "player_2": 0})
             if any(terms.values()):
                 break
-        record = wrapped.get_episode_record()
+        record = wrapped.get_game_record()
         assert record is not None
         # Total rounds should match total score
         assert len(record.rounds) == sum(record.scores)
@@ -329,13 +329,13 @@ class TestRecordEpisode:
 
     def test_frames_grouped_by_round(self):
         e = env(winning_score=3)
-        wrapped = RecordEpisode(e)
+        wrapped = RecordGame(e)
         wrapped.reset(seed=42)
         for _ in range(5000):
             obs, rewards, terms, _, _ = wrapped.step({"player_1": 0, "player_2": 0})
             if any(terms.values()):
                 break
-        record = wrapped.get_episode_record()
+        record = wrapped.get_game_record()
         # Each round should have non-empty frames
         for r in record.rounds:
             assert len(r.frames) > 0
@@ -348,13 +348,13 @@ class TestRecordEpisode:
 
     def test_round_reward(self):
         e = env(winning_score=2)
-        wrapped = RecordEpisode(e)
+        wrapped = RecordGame(e)
         wrapped.reset(seed=42)
         for _ in range(3000):
             obs, rewards, terms, _, _ = wrapped.step({"player_1": 0, "player_2": 0})
             if any(terms.values()):
                 break
-        record = wrapped.get_episode_record()
+        record = wrapped.get_game_record()
         for r in record.rounds:
             # Reward should be zero-sum
             assert r.reward["player_1"] + r.reward["player_2"] == pytest.approx(0.0)
@@ -363,13 +363,13 @@ class TestRecordEpisode:
 
     def test_winner(self):
         e = env(winning_score=2)
-        wrapped = RecordEpisode(e)
+        wrapped = RecordGame(e)
         wrapped.reset(seed=42)
         for _ in range(3000):
             obs, rewards, terms, _, _ = wrapped.step({"player_1": 0, "player_2": 0})
             if any(terms.values()):
                 break
-        record = wrapped.get_episode_record()
+        record = wrapped.get_game_record()
         assert record.winner is not None
         # Winner should be the player with higher score
         if record.scores[0] > record.scores[1]:
@@ -380,13 +380,13 @@ class TestRecordEpisode:
     def test_server_tracking(self):
         """First round server should be player_1, then scorer serves next."""
         e = env(winning_score=3)
-        wrapped = RecordEpisode(e)
+        wrapped = RecordGame(e)
         wrapped.reset(seed=42)
         for _ in range(5000):
             obs, rewards, terms, _, _ = wrapped.step({"player_1": 0, "player_2": 0})
             if any(terms.values()):
                 break
-        record = wrapped.get_episode_record()
+        record = wrapped.get_game_record()
         # First round: player_1 serves (default)
         assert record.rounds[0].server == "player_1"
         # Subsequent rounds: scorer of previous round serves
@@ -395,25 +395,25 @@ class TestRecordEpisode:
 
     def test_round_duration(self):
         e = env(winning_score=2)
-        wrapped = RecordEpisode(e)
+        wrapped = RecordGame(e)
         wrapped.reset(seed=42)
         for _ in range(3000):
             obs, rewards, terms, _, _ = wrapped.step({"player_1": 0, "player_2": 0})
             if any(terms.values()):
                 break
-        record = wrapped.get_episode_record()
+        record = wrapped.get_game_record()
         for r in record.rounds:
             assert r.duration == r.end_frame - r.start_frame + 1
             assert r.duration == len(r.frames)
 
     def test_no_frames_when_disabled(self):
         e = env(winning_score=1)
-        wrapped = RecordEpisode(e, record_frames=False)
+        wrapped = RecordGame(e, record_frames=False)
         wrapped.reset(seed=42)
         for _ in range(300):
             obs, rewards, terms, _, _ = wrapped.step({"player_1": 0, "player_2": 0})
             if any(terms.values()):
                 break
-        record = wrapped.get_episode_record()
+        record = wrapped.get_game_record()
         assert record.total_frames > 0
         assert len(record.frames) == 0


### PR DESCRIPTION
## Summary
- `RecordEpisode` → `RecordGame`, `EpisodeRecord` → `GameRecord`
- `get_episode_record()` → `get_game_record()`
- `record_episode.py` → `record_game.py`
- `infos[agent]["episode"]` 키는 SB3/Gymnasium 호환을 위해 유지 (A안)
- wrappers README, tests 동기화

Closes #41

## Test plan
- [x] `uv run pytest` — 82 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)