### PR TITLE
fix(ai): SB3ModelPolicy builds observation from physics state directly

### DIFF
--- a/src/pika_zoo/ai/sb3_adapter.py
+++ b/src/pika_zoo/ai/sb3_adapter.py
@@ -14,6 +14,7 @@ from numpy.random import Generator
 from pika_zoo.engine.physics import Ball, Player
 from pika_zoo.engine.types import UserInput
 from pika_zoo.env.actions import ACTION_TABLE
+from pika_zoo.env.observations import build_observation
 from pika_zoo.wrappers.normalize_observation import OBS_LOW, OBS_RANGE
 from pika_zoo.wrappers.simplify_action import P1_MAP, P2_MAP
 from pika_zoo.wrappers.simplify_observation import _mirror
@@ -30,6 +31,8 @@ class SB3ModelPolicy:
     The model receives a processed observation and returns a discrete action.
     This adapter converts between the engine's Player/Ball state and the
     model's expected observation format.
+
+    Works both as an ai_policy in PikachuVolleyballEnv and with the play script.
 
     Args:
         model_path: Path to saved SB3 model (.zip).
@@ -69,11 +72,8 @@ class SB3ModelPolicy:
         self._observation_simplified = observation_simplified and agent == "player_2"
         self._observation_normalized = observation_normalized
         self._action_map: list[int] | None = _SIMPLIFIED_MAPS.get(agent) if action_simplified else None
-        self._last_obs = None
-
-    def set_observation(self, obs) -> None:
-        """Set the latest observation for this player (called by play script)."""
-        self._last_obs = obs
+        self._prev_power_hit: int = 0
+        self._opponent_prev_power_hit: int = 0
 
     def compute_action(
         self,
@@ -82,11 +82,9 @@ class SB3ModelPolicy:
         opponent: Player,
         rng: Generator,
     ) -> UserInput:
-        """Predict action from the model using the stored observation."""
-        if self._last_obs is None:
-            return UserInput()
+        """Predict action from the model using current game state."""
+        obs = build_observation(player, opponent, ball, self._prev_power_hit, self._opponent_prev_power_hit)
 
-        obs = self._last_obs
         if self._observation_simplified:
             obs = _mirror(obs)
         if self._observation_normalized:
@@ -105,7 +103,12 @@ class SB3ModelPolicy:
         user_input.x_direction = -int(keys[0]) + int(keys[1])
         user_input.y_direction = -int(keys[2]) + int(keys[3])
         user_input.power_hit = int(keys[4])
+
+        # Track power_hit for next frame's observation
+        self._prev_power_hit = int(keys[4])
+
         return user_input
 
     def reset(self, rng: Generator) -> None:
-        self._last_obs = None
+        self._prev_power_hit = 0
+        self._opponent_prev_power_hit = 0

--- a/src/pika_zoo/scripts/play.py
+++ b/src/pika_zoo/scripts/play.py
@@ -71,7 +71,6 @@ def play(
             p2_human = False
 
     ai_policies = {}
-    sb3_policies: dict[str, object] = {}  # SB3 models need obs updates
 
     for agent, spec, is_human in [("player_1", p1, p1_human), ("player_2", p2, p2_human)]:
         if is_human:
@@ -79,9 +78,7 @@ def play(
         if Path(spec).exists():
             from pika_zoo.ai.sb3_adapter import SB3ModelPolicy
 
-            policy = SB3ModelPolicy(spec, agent=agent)
-            ai_policies[agent] = policy
-            sb3_policies[agent] = policy
+            ai_policies[agent] = SB3ModelPolicy(spec, agent=agent)
         else:
             ai_policies[agent] = get_ai(spec)
 
@@ -129,7 +126,7 @@ def play(
         from pika_zoo.wrappers import RecordGame
 
         e = RecordGame(e)
-    cached_obs, _ = e.reset(seed=seed)
+    e.reset(seed=seed)
 
     # Print match info
     print(f"Pikachu Volleyball — {p1_label} vs {p2_label} (first to {winning_score})")
@@ -185,13 +182,7 @@ def play(
             if p2_human:
                 actions["player_2"] = get_action_from_keys(keys, "player_2")
 
-        # Feed cached observations to SB3 models before step
-        if sb3_policies and cached_obs is not None:
-            for agent, policy in sb3_policies.items():
-                policy.set_observation(cached_obs[agent])
-
         obs, rewards, terms, truncs, infos = e.step(actions)
-        cached_obs = obs
 
         # Render + capture for recording
         if render_mode is not None:


### PR DESCRIPTION
## Summary
- `compute_action()`에서 `build_observation()`을 직접 호출하여 obs 구성
- `set_observation()` / `_last_obs` 제거
- play.py에서 수동 obs feeding (`sb3_policies`, `cached_obs`) 제거
- `ai_policies`에 등록해도 정상 동작

Closes #48

## Test plan
- [x] `uv run pytest` — 85 tests passing
- [x] 과적합 모델 5-0 승리 확인 (play.py 경로)

🤖 Generated with [Claude Code](https://claude.com/claude-code)