### PR TITLE
feat(scripts): custom keymap support

### DIFF
--- a/src/pika_zoo/scripts/README.md
+++ b/src/pika_zoo/scripts/README.md
@@ -22,7 +22,7 @@ uv run play --no-render                            # headless (stats only)
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--p1`, `--p2` | `builtin` | Player spec: `"builtin"`, `"random"`, `"human"`, or path to `.zip` model |
+| `--p1`, `--p2` | `builtin` | Player spec: `"builtin"`, `"duckll"`, `"duckll:N"`, `"random"`, `"stone"`, `"human"`, or model path |
 | `--winning-score` | 15 | Score to win |
 | `--seed` | None | Random seed |
 | `--fps` | 25 | Frame rate |
@@ -32,18 +32,26 @@ uv run play --no-render                            # headless (stats only)
 | `--noise-x N` | None | Ball x position noise ±N pixels |
 | `--noise-x-vel N` | None | Ball x velocity noise ±N |
 | `--noise-y-vel N` | None | Ball y velocity noise ±N |
-| `--p1-skin`, `--p2-skin` | auto | Override pikachu skin |
+| `--p1-skin`, `--p2-skin` | auto | Override pikachu skin (azure, gray, lime, orange, white, yellow) |
 | `--p1-label`, `--p2-label` | auto | Override display label |
+| `--p1-keymap`, `--p2-keymap` | P1=original, P2=arrows | Keyboard layout preset |
 
 ### Keyboard Controls
 
-| Player 1 | Player 2 | Action |
-|----------|----------|--------|
-| D | Left arrow | Move left |
-| G | Right arrow | Move right |
-| R | Up arrow | Jump |
-| V | Down arrow | Dive |
-| Z | Enter | Power hit |
+Three keymap presets are available, selectable via `--p1-keymap` / `--p2-keymap`:
+
+| Action | `original` (P1 default) | `wasd` | `arrows` (P2 default) |
+|--------|------------------------|--------|----------------------|
+| Move left | D | A | Left arrow |
+| Move right | G | D | Right arrow |
+| Jump | R | W | Up arrow |
+| Dive | V | S | Down arrow |
+| Power hit | Z | Enter | Space |
+
+```bash
+uv run play --p1 human --p2 duckll --p1-keymap arrows    # P1 uses arrow keys
+uv run play --p1 human --p2 human --p1-keymap wasd --p2-keymap arrows
+```
 
 ## Files
 

--- a/src/pika_zoo/scripts/keyboard.py
+++ b/src/pika_zoo/scripts/keyboard.py
@@ -1,9 +1,10 @@
 """
 Keyboard input handler for human players.
 
-Key bindings (matching original game):
-  Player 1: D(left) G(right) R(up) V(down) Z(power hit)
-  Player 2: Arrow keys + Enter (power hit)
+Supports multiple keymap presets:
+  original:   D(left) G(right) R(up) V(down) Z(power hit)
+  wasd:       A(left) D(right) W(up) S(down) Enter(power hit)
+  arrows:     Arrow keys + Space(power hit)
 
 Returns a discrete action index (0-17) compatible with the env's action space.
 """
@@ -15,36 +16,71 @@ import pygame
 
 from pika_zoo.env.actions import ACTION_TABLE
 
-# Player 1: D/G/R/V + Z (original game layout)
-P1_KEYS = {
-    "left": pygame.K_d,
-    "right": pygame.K_g,
-    "up": pygame.K_r,
-    "down": pygame.K_v,
-    "power": pygame.K_z,
+# Keymap presets: each maps logical actions to pygame keys
+KEYMAPS: dict[str, dict[str, int]] = {
+    "original": {
+        "left": pygame.K_d,
+        "right": pygame.K_g,
+        "up": pygame.K_r,
+        "down": pygame.K_v,
+        "power": pygame.K_z,
+    },
+    "wasd": {
+        "left": pygame.K_a,
+        "right": pygame.K_d,
+        "up": pygame.K_w,
+        "down": pygame.K_s,
+        "power": pygame.K_RETURN,
+    },
+    "arrows": {
+        "left": pygame.K_LEFT,
+        "right": pygame.K_RIGHT,
+        "up": pygame.K_UP,
+        "down": pygame.K_DOWN,
+        "power": pygame.K_SPACE,
+    },
 }
 
-# Player 2: Arrow keys + Enter
-P2_KEYS = {
-    "left": pygame.K_LEFT,
-    "right": pygame.K_RIGHT,
-    "up": pygame.K_UP,
-    "down": pygame.K_DOWN,
-    "power": pygame.K_RETURN,
-}
+# Default keymaps per player
+DEFAULT_KEYMAPS = {"player_1": "original", "player_2": "arrows"}
 
 
-def get_action_from_keys(keys: pygame.key.ScancodeWrapper, player: str = "player_1") -> int:
+def get_keymap(name: str) -> dict[str, int]:
+    """Get a keymap by name."""
+    if name not in KEYMAPS:
+        available = ", ".join(sorted(KEYMAPS.keys()))
+        raise KeyError(f"Unknown keymap: {name!r}. Available: {available}")
+    return KEYMAPS[name]
+
+
+def keymap_help(name: str) -> str:
+    """Return a human-readable description of a keymap."""
+    km = get_keymap(name)
+    key_name = pygame.key.name
+    return (
+        f"{key_name(km['left'])}(left) {key_name(km['right'])}(right) "
+        f"{key_name(km['up'])}(up) {key_name(km['down'])}(down) "
+        f"{key_name(km['power'])}(power hit)"
+    )
+
+
+def get_action_from_keys(
+    keys: pygame.key.ScancodeWrapper,
+    player: str = "player_1",
+    keymap: str | None = None,
+) -> int:
     """Read currently pressed keys and return the matching action index.
 
     Args:
         keys: Result of pygame.key.get_pressed()
         player: "player_1" or "player_2"
+        keymap: Keymap preset name. If None, uses the default for the player.
 
     Returns:
         Discrete action index (0-17)
     """
-    bindings = P1_KEYS if player == "player_1" else P2_KEYS
+    keymap_name = keymap or DEFAULT_KEYMAPS[player]
+    bindings = get_keymap(keymap_name)
 
     key_array = np.array(
         [

--- a/src/pika_zoo/scripts/play.py
+++ b/src/pika_zoo/scripts/play.py
@@ -39,6 +39,8 @@ def play(
     p2_skin: str | None = None,
     p1_label: str | None = None,
     p2_label: str | None = None,
+    p1_keymap: str | None = None,
+    p2_keymap: str | None = None,
 ) -> None:
     """Run a Pikachu Volleyball match.
 
@@ -133,10 +135,15 @@ def play(
 
     # Print match info
     print(f"Pikachu Volleyball — {p1_label} vs {p2_label} (first to {winning_score})")
-    if p1_human:
-        print("  P1: D(left) G(right) R(up) V(down) Z(power hit)")
-    if p2_human:
-        print("  P2: Arrow keys + Enter (power hit)")
+    if p1_human or p2_human:
+        from pika_zoo.scripts.keyboard import keymap_help
+
+        if p1_human:
+            km = p1_keymap or "original"
+            print(f"  P1: {keymap_help(km)}")
+        if p2_human:
+            km = p2_keymap or "arrows"
+            print(f"  P2: {keymap_help(km)}")
 
     # Init render if needed
     if render_mode is not None:
@@ -181,9 +188,9 @@ def play(
         if pygame is not None and (p1_human or p2_human):
             keys = pygame.key.get_pressed()
             if p1_human:
-                actions["player_1"] = get_action_from_keys(keys, "player_1")
+                actions["player_1"] = get_action_from_keys(keys, "player_1", keymap=p1_keymap)
             if p2_human:
-                actions["player_2"] = get_action_from_keys(keys, "player_2")
+                actions["player_2"] = get_action_from_keys(keys, "player_2", keymap=p2_keymap)
 
         obs, rewards, terms, truncs, infos = e.step(actions)
 
@@ -261,6 +268,8 @@ def main(argv: list[str] | None = None) -> None:
     )
     parser.add_argument("--p1-label", type=str, default=None, help="P1 display label (default: auto)")
     parser.add_argument("--p2-label", type=str, default=None, help="P2 display label (default: auto)")
+    parser.add_argument("--p1-keymap", type=str, default=None, help="P1 keymap (available: original, wasd, arrows)")
+    parser.add_argument("--p2-keymap", type=str, default=None, help="P2 keymap (available: original, wasd, arrows)")
     args = parser.parse_args(argv)
 
     play(
@@ -277,6 +286,8 @@ def main(argv: list[str] | None = None) -> None:
         p2_skin=args.p2_skin,
         p1_label=args.p1_label,
         p2_label=args.p2_label,
+        p1_keymap=args.p1_keymap,
+        p2_keymap=args.p2_keymap,
     )
 
 


### PR DESCRIPTION
## Summary

플레이 시 커스텀 키맵을 선택할 수 있도록 합니다. (#55)

### 프리셋
| 이름 | 키 배치 |
|------|---------|
| `original` | D/G/R/V + Z (원작) |
| `wasd` | A/D/W/S + Enter |
| `arrows` | 방향키 + Space |

### 사용법
```bash
uv run play --p1 human --p2 duckll --p1-keymap arrows
uv run play --p1 human --p2 human --p1-keymap wasd --p2-keymap arrows
```

기본값: P1=original, P2=arrows

## Test plan

- [x] `uv run pytest` — 81 passed
- [x] `--p1-keymap arrows` 로 방향키+스페이스바 조작 확인
- [x] `uv run play --help` 에 keymap 옵션 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)