### PR TITLE
feat(wrappers): add frame stacking support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Python port of the reverse-engineered JS source code, wrapped with standard RL i
 - **Physics Engine**: Accurately reproduces the original ball trajectory, character movement, net collision, and scoring logic
 - **PettingZoo**: Two-player multi-agent environment (`ParallelEnv`)
 - **Gymnasium**: Single-agent wrapper (opponent fixed with a built-in policy)
-- **Wrappers**: Action/observation simplification, normalization, reward shaping — all opt-in and composable
+- **Wrappers**: Action/observation simplification, normalization, frame stacking, reward shaping — all opt-in and composable
 - **Rendering**: Pygame-based visualization with player skins, score overlay, and headless MP4 recording
 - **Episode Recording**: Per-round statistics, frame-by-frame state snapshots, and JSON export for replay analysis
 - **AI Opponents**: BuiltinAI (original), DuckllAI (11 difficulty levels), StoneAI, RandomAI — pluggable via `AIPolicy` protocol
@@ -98,12 +98,13 @@ uv run ruff check .
 
 ```python
 from pika_zoo.env import env
-from pika_zoo.wrappers import SimplifyAction, SimplifyObservation, NormalizeObservation, ConvertSingleAgent
+from pika_zoo.wrappers import FrameStack, SimplifyAction, SimplifyObservation, NormalizeObservation, ConvertSingleAgent
 
 e = env(winning_score=15)
 e = SimplifyAction(e)              # 18 → 13 relative actions
 e = SimplifyObservation(e)         # mirror player_2 x-axis (optional)
 e = NormalizeObservation(e)        # scale observations to [0, 1]
+e = FrameStack(e, n_frames=4)      # stack recent frames as (4, 35) (optional)
 e = ConvertSingleAgent(e)          # PettingZoo → Gymnasium for SB3
 ```
 

--- a/src/pika_zoo/ai/README.md
+++ b/src/pika_zoo/ai/README.md
@@ -67,6 +67,7 @@ SB3ModelPolicy(
     action_simplified=True,        # remap 13 simplified actions → 18 raw actions
     observation_simplified=False,  # mirror player_2 x-axis (SimplifyObservation)
     observation_normalized=True,   # normalize observations to [0, 1]
+    frame_stack=4,                 # stack recent frames for models trained with FrameStack
 )
 ```
 
@@ -75,8 +76,9 @@ SB3ModelPolicy(
 | `action_simplified` | `True` | `SimplifyAction` — remap model output (0–12) to raw actions (0–17) |
 | `observation_simplified` | `False` | `SimplifyObservation` — mirror player_2 x-axis (only applied for player_2) |
 | `observation_normalized` | `True` | `NormalizeObservation` — min-max scale to [0, 1] |
+| `frame_stack` | `1` | `FrameStack` — maintain an inference-time buffer and pass `(N, 35)` to the model |
 
-Processing order: simplify → normalize (same as wrapper stacking order).
+Processing order: simplify → normalize → frame stack (same as wrapper stacking order).
 
 ## Registry
 

--- a/src/pika_zoo/ai/sb3_adapter.py
+++ b/src/pika_zoo/ai/sb3_adapter.py
@@ -6,6 +6,7 @@ SB3 (stable-baselines3) is an optional dependency — only imported when used.
 
 from __future__ import annotations
 
+from collections import deque
 from pathlib import Path
 
 import numpy as np
@@ -43,6 +44,8 @@ class SB3ModelPolicy:
             using the same transform as SimplifyObservation (default False).
         observation_normalized: If True, normalize raw observations to [0, 1]
             using the same min-max scaling as NormalizeObservation (default True).
+        frame_stack: Number of processed observations to stack for models trained
+            with FrameStack. 1 disables stacking and preserves existing behavior.
         agent: Agent name ("player_1" or "player_2").
             Required when action_simplified=True or observation_simplified=True.
     """
@@ -54,12 +57,17 @@ class SB3ModelPolicy:
         action_simplified: bool = True,
         observation_simplified: bool = False,
         observation_normalized: bool = True,
+        frame_stack: int = 1,
         agent: str | None = None,
     ) -> None:
         if (action_simplified or observation_simplified) and agent is None:
             raise ValueError("agent must be specified when action_simplified=True or observation_simplified=True")
         if action_simplified and agent not in _SIMPLIFIED_MAPS:
             raise ValueError(f"Unknown agent: {agent!r}. Must be 'player_1' or 'player_2'.")
+        if not isinstance(frame_stack, int):
+            raise TypeError("frame_stack must be an int")
+        if frame_stack < 1:
+            raise ValueError("frame_stack must be >= 1")
         try:
             from stable_baselines3 import PPO
         except ImportError:
@@ -72,6 +80,8 @@ class SB3ModelPolicy:
         self._observation_simplified = observation_simplified and agent == "player_2"
         self._observation_normalized = observation_normalized
         self._action_map: list[int] | None = _SIMPLIFIED_MAPS.get(agent) if action_simplified else None
+        self._frame_stack = frame_stack
+        self._frame_buffer: deque[np.ndarray] | None = deque(maxlen=frame_stack) if frame_stack > 1 else None
         self._prev_power_hit: int = 0
         self._opponent_prev_power_hit: int = 0
 
@@ -90,7 +100,8 @@ class SB3ModelPolicy:
         if self._observation_normalized:
             obs = np.clip((obs - OBS_LOW) / OBS_RANGE, 0.0, 1.0).astype(np.float32)
 
-        action, _ = self._model.predict(obs, deterministic=self._deterministic)
+        model_obs = self._stack_observation(obs)
+        action, _ = self._model.predict(model_obs, deterministic=self._deterministic)
         action_idx = int(action)
 
         # Remap simplified (13) action to raw (18) action if needed
@@ -112,3 +123,15 @@ class SB3ModelPolicy:
     def reset(self, rng: Generator) -> None:
         self._prev_power_hit = 0
         self._opponent_prev_power_hit = 0
+        if self._frame_buffer is not None:
+            self._frame_buffer.clear()
+
+    def _stack_observation(self, obs: np.ndarray) -> np.ndarray:
+        if self._frame_buffer is None:
+            return obs
+
+        self._frame_buffer.append(obs.copy())
+        frames = list(self._frame_buffer)
+        if len(frames) < self._frame_stack:
+            frames = [frames[0]] * (self._frame_stack - len(frames)) + frames
+        return np.stack(frames, axis=0).astype(obs.dtype, copy=False)

--- a/src/pika_zoo/env/pikachu_volleyball.py
+++ b/src/pika_zoo/env/pikachu_volleyball.py
@@ -134,6 +134,8 @@ class PikachuVolleyballEnv(ParallelEnv):
             self._physics.ball.initialize_for_new_round(self._is_player2_serve, noise=self.noise, rng=self._np_random)
             self._apply_initial_positions()
             self._round_ended = False
+            for policy in self.ai_policies.values():
+                policy.reset(self._np_random)
             for converter in self._action_converters.values():
                 converter.reset()
 

--- a/src/pika_zoo/scripts/README.md
+++ b/src/pika_zoo/scripts/README.md
@@ -19,6 +19,24 @@ uv run play --record match.mp4                     # windowed + recording
 uv run play --no-render                            # headless (stats only)
 ```
 
+### Model Directory Config
+
+When `--p1` or `--p2` points to a directory, `play` loads the single `.zip` file plus an optional `.json` config.
+Supported config keys are passed to `SB3ModelPolicy`:
+
+```json
+{
+  "side": "both",
+  "action_simplified": true,
+  "observation_simplified": false,
+  "observation_normalized": true,
+  "frame_stack": 4
+}
+```
+
+`frame_stack` defaults to `1` for existing models. Values greater than 1 make the policy keep its own
+inference-time frame buffer and pass `(N, 35)` observations to the SB3 model.
+
 ### Options
 
 | Flag | Default | Description |

--- a/src/pika_zoo/wrappers/README.md
+++ b/src/pika_zoo/wrappers/README.md
@@ -9,11 +9,13 @@ e = env(winning_score=15)
 e = SimplifyAction(e)              # 1. action space reduction
 e = SimplifyObservation(e)         # 2. x-axis mirroring (optional)
 e = NormalizeObservation(e)        # 3. observation scaling
-e = RewardShaping(e)               # 4. shaped rewards (optional)
-e = ConvertSingleAgent(e)          # 5. multi-agent → single-agent
+e = FrameStack(e, n_frames=4)      # 4. temporal stacking (optional)
+e = RewardShaping(e)               # 5. shaped rewards (optional)
+e = ConvertSingleAgent(e)          # 6. multi-agent → single-agent
 ```
 
 `SimplifyObservation` must come before `NormalizeObservation` — mirroring operates on raw coordinates.
+`FrameStack` should come after observation transforms so each stored frame has the model-ready format.
 
 ## SimplifyAction
 
@@ -58,6 +60,21 @@ All other features (y positions, y velocities, states, etc.) are left unchanged.
 ## NormalizeObservation
 
 Min-max scales all observation features to [0, 1] using known physical ranges. Uses fixed bounds — no running statistics.
+
+## FrameStack
+
+Stacks the most recent N observations along a leading time axis:
+
+```python
+from pika_zoo.wrappers import FrameStack
+
+e = FrameStack(e, n_frames=4)
+# obs shape: (35,) -> (4, 35)
+```
+
+On `reset()`, the initial observation is repeated N times so the observation shape is stable from the first step.
+On each `step()`, the newest observation is appended and the oldest frame is dropped. The stack is not flattened; MLP
+policies can flatten internally while recurrent or convolutional policies can keep the time dimension.
 
 ## RewardShaping
 
@@ -149,6 +166,7 @@ record.to_dict()                # JSON export
 | `simplify_action.py` | 18 → 13 relative-direction actions |
 | `simplify_observation.py` | Mirror player_2 x-axis observations |
 | `normalize_observation.py` | Min-max normalization to [0, 1] |
+| `frame_stack.py` | Stack recent observations as `(n_frames, 35)` |
 | `reward_shaping.py` | Pluggable reward channels wrapper |
 | `reward_channels.py` | Built-in reward channel functions |
 | `convert_single_agent.py` | ParallelEnv → Gymnasium for SB3 |

--- a/src/pika_zoo/wrappers/README.md
+++ b/src/pika_zoo/wrappers/README.md
@@ -73,8 +73,10 @@ e = FrameStack(e, n_frames=4)
 ```
 
 On `reset()`, the initial observation is repeated N times so the observation shape is stable from the first step.
-On each `step()`, the newest observation is appended and the oldest frame is dropped. The stack is not flattened; MLP
-policies can flatten internally while recurrent or convolutional policies can keep the time dimension.
+On each `step()`, the newest observation is appended and the oldest frame is dropped. After a scoring frame, the next
+round's first returned observation resets the stack to repeated copies of that new-round observation, preventing the
+previous round's terminal state from leaking into the next rally. The stack is not flattened; MLP policies can flatten
+internally while recurrent or convolutional policies can keep the time dimension.
 
 ## RewardShaping
 

--- a/src/pika_zoo/wrappers/__init__.py
+++ b/src/pika_zoo/wrappers/__init__.py
@@ -1,5 +1,6 @@
 from pika_zoo.records import FrameRecord, FrameSnapshot, GameRecord, GamesRecord, RoundRecord
 from pika_zoo.wrappers.convert_single_agent import ConvertSingleAgent
+from pika_zoo.wrappers.frame_stack import FrameStack
 from pika_zoo.wrappers.normalize_observation import NormalizeObservation
 from pika_zoo.wrappers.record_game import RecordGame
 from pika_zoo.wrappers.reward_channels import (
@@ -15,6 +16,7 @@ from pika_zoo.wrappers.simplify_observation import SimplifyObservation
 
 __all__ = [
     "ConvertSingleAgent",
+    "FrameStack",
     "FrameRecord",
     "FrameSnapshot",
     "GameRecord",

--- a/src/pika_zoo/wrappers/frame_stack.py
+++ b/src/pika_zoo/wrappers/frame_stack.py
@@ -25,6 +25,7 @@ class FrameStack(BaseParallelWrapper):
             raise ValueError("n_frames must be >= 1")
         self.n_frames = n_frames
         self._buffers: dict[str, deque[np.ndarray]] = {}
+        self._reset_next_step = False
 
     def observation_space(self, agent: str) -> spaces.Box:
         base_space = self.env.observation_space(agent)
@@ -37,18 +38,33 @@ class FrameStack(BaseParallelWrapper):
     def reset(self, seed=None, options=None):
         observations, infos = super().reset(seed=seed, options=options)
         self._buffers = {}
+        self._reset_next_step = False
         for agent, obs in observations.items():
             self._buffers[agent] = deque([obs.copy() for _ in range(self.n_frames)], maxlen=self.n_frames)
         return self._stack_observations(observations), infos
 
     def step(self, actions):
         observations, rewards, terminations, truncations, infos = super().step(actions)
-        for agent, obs in observations.items():
-            if agent not in self._buffers:
-                self._buffers[agent] = deque([obs.copy() for _ in range(self.n_frames)], maxlen=self.n_frames)
-            else:
-                self._buffers[agent].append(obs.copy())
-        return self._stack_observations(observations), rewards, terminations, truncations, infos
+        if self._reset_next_step:
+            self._reset_buffers(observations)
+            self._reset_next_step = False
+        else:
+            for agent, obs in observations.items():
+                if agent not in self._buffers:
+                    self._buffers[agent] = deque([obs.copy() for _ in range(self.n_frames)], maxlen=self.n_frames)
+                else:
+                    self._buffers[agent].append(obs.copy())
+
+        stacked = self._stack_observations(observations)
+        if any(info.get("round_ended", False) for info in infos.values()) and not any(terminations.values()):
+            self._reset_next_step = True
+        return stacked, rewards, terminations, truncations, infos
+
+    def _reset_buffers(self, observations: dict[str, np.ndarray]) -> None:
+        self._buffers = {
+            agent: deque([obs.copy() for _ in range(self.n_frames)], maxlen=self.n_frames)
+            for agent, obs in observations.items()
+        }
 
     def _stack_observations(self, observations: dict[str, np.ndarray]) -> dict[str, np.ndarray]:
         return {agent: np.stack(list(self._buffers[agent]), axis=0) for agent in observations}

--- a/src/pika_zoo/wrappers/frame_stack.py
+++ b/src/pika_zoo/wrappers/frame_stack.py
@@ -1,0 +1,54 @@
+"""
+Wrapper that stacks the last N observations along a time axis.
+
+This preserves temporal structure as (n_frames, observation_size) instead of
+flattening into a single vector.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+
+import numpy as np
+from gymnasium import spaces
+from pettingzoo.utils import BaseParallelWrapper
+
+
+class FrameStack(BaseParallelWrapper):
+    """Stack the last n_frames observations for each agent."""
+
+    def __init__(self, env, n_frames: int = 4) -> None:
+        super().__init__(env)
+        if not isinstance(n_frames, int):
+            raise TypeError("n_frames must be an int")
+        if n_frames < 1:
+            raise ValueError("n_frames must be >= 1")
+        self.n_frames = n_frames
+        self._buffers: dict[str, deque[np.ndarray]] = {}
+
+    def observation_space(self, agent: str) -> spaces.Box:
+        base_space = self.env.observation_space(agent)
+        if not isinstance(base_space, spaces.Box):
+            raise TypeError("FrameStack only supports Box observation spaces")
+        low = np.stack([base_space.low] * self.n_frames, axis=0)
+        high = np.stack([base_space.high] * self.n_frames, axis=0)
+        return spaces.Box(low=low, high=high, dtype=base_space.dtype)
+
+    def reset(self, seed=None, options=None):
+        observations, infos = super().reset(seed=seed, options=options)
+        self._buffers = {}
+        for agent, obs in observations.items():
+            self._buffers[agent] = deque([obs.copy() for _ in range(self.n_frames)], maxlen=self.n_frames)
+        return self._stack_observations(observations), infos
+
+    def step(self, actions):
+        observations, rewards, terminations, truncations, infos = super().step(actions)
+        for agent, obs in observations.items():
+            if agent not in self._buffers:
+                self._buffers[agent] = deque([obs.copy() for _ in range(self.n_frames)], maxlen=self.n_frames)
+            else:
+                self._buffers[agent].append(obs.copy())
+        return self._stack_observations(observations), rewards, terminations, truncations, infos
+
+    def _stack_observations(self, observations: dict[str, np.ndarray]) -> dict[str, np.ndarray]:
+        return {agent: np.stack(list(self._buffers[agent]), axis=0) for agent in observations}

--- a/tests/test_ai.py
+++ b/tests/test_ai.py
@@ -1,12 +1,17 @@
 """Tests for the AI module."""
 
+import sys
+import types
+
 import numpy as np
+import pytest
 
 from pika_zoo.ai.builtin import BuiltinAI
 from pika_zoo.ai.protocol import AIPolicy
 from pika_zoo.ai.registry import get_ai, register_ai
 from pika_zoo.engine.physics import PikaPhysics
 from pika_zoo.engine.types import UserInput
+from pika_zoo.env.observations import OBSERVATION_SIZE
 
 
 class TestAIProtocol:
@@ -87,3 +92,98 @@ class TestRegistry:
 
         with pytest.raises(KeyError, match="Unknown AI"):
             get_ai("nonexistent")
+
+
+class TestSB3ModelPolicy:
+    def test_frame_stack_passes_stacked_observation(self, monkeypatch, tmp_path):
+        fake_model = _install_fake_sb3(monkeypatch)
+
+        from pika_zoo.ai.sb3_adapter import SB3ModelPolicy
+
+        model_path = tmp_path / "model.zip"
+        model_path.write_bytes(b"fake")
+        policy = SB3ModelPolicy(model_path, agent="player_1", frame_stack=4, observation_normalized=False)
+
+        rng = np.random.default_rng(42)
+        physics = PikaPhysics(rng)
+        policy.compute_action(physics.player1, physics.ball, physics.player2, rng)
+        physics.ball.x += 1
+        policy.compute_action(physics.player1, physics.ball, physics.player2, rng)
+
+        assert fake_model.observations[0].shape == (4, OBSERVATION_SIZE)
+        np.testing.assert_array_equal(fake_model.observations[0][0], fake_model.observations[0][-1])
+        assert fake_model.observations[1].shape == (4, OBSERVATION_SIZE)
+        np.testing.assert_array_equal(fake_model.observations[1][0], fake_model.observations[0][0])
+        np.testing.assert_array_equal(fake_model.observations[1][-1], fake_model.observations[0][-1] + _ball_x_delta())
+
+    def test_frame_stack_one_preserves_flat_observation(self, monkeypatch, tmp_path):
+        fake_model = _install_fake_sb3(monkeypatch)
+
+        from pika_zoo.ai.sb3_adapter import SB3ModelPolicy
+
+        model_path = tmp_path / "model.zip"
+        model_path.write_bytes(b"fake")
+        policy = SB3ModelPolicy(model_path, agent="player_1", frame_stack=1)
+
+        rng = np.random.default_rng(42)
+        physics = PikaPhysics(rng)
+        policy.compute_action(physics.player1, physics.ball, physics.player2, rng)
+
+        assert fake_model.observations[0].shape == (OBSERVATION_SIZE,)
+
+    def test_invalid_frame_stack(self, monkeypatch, tmp_path):
+        _install_fake_sb3(monkeypatch)
+
+        from pika_zoo.ai.sb3_adapter import SB3ModelPolicy
+
+        model_path = tmp_path / "model.zip"
+        model_path.write_bytes(b"fake")
+        with pytest.raises(ValueError, match="frame_stack"):
+            SB3ModelPolicy(model_path, agent="player_1", frame_stack=0)
+
+
+class TestModelConfig:
+    def test_load_model_dir_accepts_frame_stack(self, tmp_path):
+        from pika_zoo.scripts.play import _load_model_dir
+
+        (tmp_path / "model.zip").write_bytes(b"fake")
+        (tmp_path / "model.json").write_text(
+            '{"side": "both", "frame_stack": 4, "name": "alphachu-v2", "unknown": true}'
+        )
+
+        model_path, config = _load_model_dir(tmp_path)
+
+        assert model_path == tmp_path / "model.zip"
+        assert config["side"] == "both"
+        assert config["frame_stack"] == 4
+        assert "name" not in config
+        assert "unknown" not in config
+
+
+class _FakeModel:
+    def __init__(self) -> None:
+        self.observations = []
+
+    def predict(self, obs, deterministic=True):
+        self.observations.append(obs.copy())
+        return 0, None
+
+
+def _install_fake_sb3(monkeypatch):
+    fake_model = _FakeModel()
+    module = types.ModuleType("stable_baselines3")
+
+    class FakePPO:
+        @staticmethod
+        def load(path, device="cpu"):
+            return fake_model
+
+    module.PPO = FakePPO
+    monkeypatch.setitem(sys.modules, "stable_baselines3", module)
+    return fake_model
+
+
+def _ball_x_delta() -> np.ndarray:
+    delta = np.zeros(OBSERVATION_SIZE, dtype=np.float32)
+    delta[26] = 1.0
+    return delta

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -3,6 +3,7 @@
 import pytest
 
 from pika_zoo.ai.builtin import BuiltinAI
+from pika_zoo.engine.types import UserInput
 from pika_zoo.env import env
 from pika_zoo.env.actions import NUM_ACTIONS, ActionConverter
 from pika_zoo.env.observations import OBSERVATION_SIZE
@@ -149,6 +150,35 @@ class TestPikachuVolleyballEnv:
                 break
 
         assert game_ended
+
+    def test_ai_policy_resets_each_round(self):
+        """AI policies should reset when the env starts a new round."""
+
+        class CountingAI:
+            def __init__(self):
+                self.reset_count = 0
+
+            def compute_action(self, player, ball, opponent, rng):
+                return UserInput()
+
+            def reset(self, rng):
+                self.reset_count += 1
+
+        ai = CountingAI()
+        e = env(ai_policies={"player_2": ai}, winning_score=2)
+        e.reset(seed=42)
+        assert ai.reset_count == 1
+
+        for _ in range(3000):
+            _, _, terms, _, infos = e.step({"player_1": 0, "player_2": 0})
+            if infos["player_1"]["round_ended"]:
+                assert not any(terms.values())
+                break
+        else:
+            pytest.fail("Round should end within 3000 frames")
+
+        e.step({"player_1": 0, "player_2": 0})
+        assert ai.reset_count == 2
 
     def test_agent_centric_observations(self):
         """Each agent should see itself first in the observation."""

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -296,6 +296,24 @@ class TestFrameStack:
         with pytest.raises(ValueError, match="n_frames"):
             FrameStack(env(), n_frames=0)
 
+    def test_resets_stack_after_round_end(self):
+        e = FrameStack(env(winning_score=2), n_frames=4)
+        e.reset(seed=42)
+
+        round_ended = False
+        for _ in range(3000):
+            _, _, terms, _, infos = e.step({"player_1": 0, "player_2": 0})
+            if infos["player_1"]["round_ended"]:
+                round_ended = True
+                assert not any(terms.values())
+                break
+
+        assert round_ended
+        obs, _, _, _, infos = e.step({"player_1": 0, "player_2": 0})
+        assert not infos["player_1"]["round_ended"]
+        for i in range(3):
+            np.testing.assert_array_equal(obs["player_1"][i], obs["player_1"][i + 1])
+
 
 class TestRewardShaping:
     def test_ball_position_reward(self):

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -10,6 +10,7 @@ from pika_zoo.env import env
 from pika_zoo.env.observations import OBSERVATION_SIZE
 from pika_zoo.wrappers import (
     ConvertSingleAgent,
+    FrameStack,
     LinearBallPosition,
     NormalizeObservation,
     QuadrantBallPosition,
@@ -247,6 +248,53 @@ class TestNormalizeObservation:
         for agent_obs in obs.values():
             assert np.all(agent_obs >= 0.0)
             assert np.all(agent_obs <= 1.0)
+
+
+class TestFrameStack:
+    def test_obs_space_shape(self):
+        e = env()
+        wrapped = FrameStack(e, n_frames=4)
+        space = wrapped.observation_space("player_1")
+        assert space.shape == (4, OBSERVATION_SIZE)
+        assert space.dtype == np.float32
+
+    def test_reset_repeats_initial_observation(self):
+        raw_env = env()
+        raw_obs, _ = raw_env.reset(seed=42)
+
+        wrapped_env = env()
+        wrapped = FrameStack(wrapped_env, n_frames=4)
+        obs, _ = wrapped.reset(seed=42)
+
+        assert obs["player_1"].shape == (4, OBSERVATION_SIZE)
+        for i in range(4):
+            np.testing.assert_array_equal(obs["player_1"][i], raw_obs["player_1"])
+
+    def test_step_appends_newest_observation(self):
+        raw_env = env()
+        initial_obs, _ = raw_env.reset(seed=42)
+        next_obs, _, _, _, _ = raw_env.step({"player_1": 0, "player_2": 0})
+
+        wrapped_env = env()
+        wrapped = FrameStack(wrapped_env, n_frames=4)
+        wrapped.reset(seed=42)
+        obs, _, _, _, _ = wrapped.step({"player_1": 0, "player_2": 0})
+
+        np.testing.assert_array_equal(obs["player_1"][0], initial_obs["player_1"])
+        np.testing.assert_array_equal(obs["player_1"][1], initial_obs["player_1"])
+        np.testing.assert_array_equal(obs["player_1"][2], initial_obs["player_1"])
+        np.testing.assert_array_equal(obs["player_1"][3], next_obs["player_1"])
+
+    def test_with_normalized_observations(self):
+        e = FrameStack(NormalizeObservation(env()), n_frames=4)
+        obs, _ = e.reset(seed=42)
+        assert obs["player_1"].shape == (4, OBSERVATION_SIZE)
+        assert np.all(obs["player_1"] >= 0.0)
+        assert np.all(obs["player_1"] <= 1.0)
+
+    def test_invalid_n_frames(self):
+        with pytest.raises(ValueError, match="n_frames"):
+            FrameStack(env(), n_frames=0)
 
 
 class TestRewardShaping:


### PR DESCRIPTION
## Summary

- Add a native FrameStack wrapper that returns stacked observations as (n_frames, 35) without flattening.
- Extend SB3ModelPolicy with frame_stack so model-directory inference can keep its own frame buffer.
- Reset frame buffers at round boundaries so terminal scoring observations do not leak into the next rally.
- Document frame_stack model config support and add tests for wrapper behavior, SB3 adapter input shape, config loading, and policy reset lifecycle.

Closes #86

## Test Plan

- uv run ruff check .
- uv run ruff format --check .
- uv run pytest tests/test_env.py tests/test_wrappers.py tests/test_ai.py
- uv run pytest