### PR TITLE
chore: prepare v1.6.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ See [engine/README.md](src/pika_zoo/engine/README.md#left-right-asymmetry) for t
 
 ## Development
 
-See [CLAUDE.md](CLAUDE.md) for the full development guide.
+See [AGENTS.md](AGENTS.md) for the full development guide. [CLAUDE.md](CLAUDE.md) remains as a Claude Code compatibility shim.
 
 ### Branch Workflow
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pika-zoo"
-version = "1.5.1"
+version = "1.6.0"
 description = "Python port of Pikachu Volleyball as an RL environment, with various utilities"
 readme = "README.md"
 authors = [

--- a/src/pika_zoo/ai/README.md
+++ b/src/pika_zoo/ai/README.md
@@ -64,6 +64,7 @@ Adapter that wraps an SB3 model (PPO, etc.) as an `AIPolicy`. Used by the `play`
 SB3ModelPolicy(
     model_path="model.zip",
     agent="player_1",              # required: determines action/observation mapping
+    deterministic=True,            # greedy actions for standard evaluation
     action_simplified=True,        # remap 13 simplified actions → 18 raw actions
     observation_simplified=False,  # mirror player_2 x-axis (SimplifyObservation)
     observation_normalized=True,   # normalize observations to [0, 1]
@@ -73,12 +74,16 @@ SB3ModelPolicy(
 
 | Parameter | Default | Corresponding Wrapper |
 |-----------|---------|----------------------|
+| `deterministic` | `True` | Use greedy SB3 predictions for standard evaluation. When `False`, stochastic action sampling is seeded from the env reset RNG. |
 | `action_simplified` | `True` | `SimplifyAction` — remap model output (0–12) to raw actions (0–17) |
 | `observation_simplified` | `False` | `SimplifyObservation` — mirror player_2 x-axis (only applied for player_2) |
 | `observation_normalized` | `True` | `NormalizeObservation` — min-max scale to [0, 1] |
 | `frame_stack` | `1` | `FrameStack` — maintain an inference-time buffer and pass `(N, 35)` to the model |
 
 Processing order: simplify → normalize → frame stack (same as wrapper stacking order).
+
+Use `deterministic=True` for leaderboards, regression checks, and model comparison. Use `deterministic=False`
+only when intentionally evaluating the policy distribution; repeated games remain reproducible when their env seeds are recorded.
 
 ## Registry
 

--- a/src/pika_zoo/scripts/README.md
+++ b/src/pika_zoo/scripts/README.md
@@ -27,6 +27,7 @@ Supported config keys are passed to `SB3ModelPolicy`:
 ```json
 {
   "side": "both",
+  "deterministic": true,
   "action_simplified": true,
   "observation_simplified": false,
   "observation_normalized": true,
@@ -36,6 +37,9 @@ Supported config keys are passed to `SB3ModelPolicy`:
 
 `frame_stack` defaults to `1` for existing models. Values greater than 1 make the policy keep its own
 inference-time frame buffer and pass `(N, 35)` observations to the SB3 model.
+
+`deterministic` defaults to `true` for standard evaluation. Set it to `false` only for stochastic policy
+sampling experiments; the sampling sequence is controlled by `--seed`.
 
 ### Options
 

--- a/uv.lock
+++ b/uv.lock
@@ -138,7 +138,7 @@ wheels = [
 
 [[package]]
 name = "pika-zoo"
-version = "1.5.1"
+version = "1.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "gymnasium" },


### PR DESCRIPTION
## Summary
- Bump package version from 1.5.1 to 1.6.0 in pyproject.toml and uv.lock.
- Update docs to point to AGENTS.md as the canonical development guide.
- Document SB3ModelPolicy deterministic/stochastic evaluation behavior.

## Test Plan
- .venv/bin/python -m pytest
- .venv/bin/python -m ruff check src tests
- .venv/bin/python -m ruff format --check src tests