### PR TITLE
feat(env): add match option overlays

### DIFF
--- a/src/pika_zoo/engine/README.md
+++ b/src/pika_zoo/engine/README.md
@@ -36,6 +36,7 @@ States: `NORMAL`(0), `JUMPING`(1), `JUMPING_POWER_HIT`(2), `DIVING`(3), `LYING_D
 ### Ball
 
 Starts at x=56 (player 1 serve) or x=376 (player 2 serve), y=0, y_velocity=1 (falling).
+`NoiseConfig` can add optional initialization noise to x position and velocity, plus an optional display-only `name`.
 
 Collision handling:
 - **Walls**: left at x < 20 (surface), right at x > 432 (center — see asymmetry note)

--- a/src/pika_zoo/engine/types.py
+++ b/src/pika_zoo/engine/types.py
@@ -16,11 +16,13 @@ class NoiseConfig:
 
     Each value specifies the ± range for uniform random noise.
     For example, x_range=5 means x += rng.integers(-5, 6).
+    The optional name is display-only and does not affect physics.
     """
 
     x_range: int
     x_velocity_range: int
     y_velocity_range: int
+    name: str | None = None
 
 
 class PlayerState(IntEnum):

--- a/src/pika_zoo/env/README.md
+++ b/src/pika_zoo/env/README.md
@@ -10,6 +10,7 @@ PettingZoo `ParallelEnv` for Pikachu Volleyball. Two agents (`player_1`, `player
 |-------|----------|
 | `"winner"` | Scorer serves the next round. This is the default and matches the original game, so use it for evaluation. |
 | `"loser"` | The player who lost the previous point serves the next round. |
+| `"alternate"` | Server alternates by round, independent of who scored. |
 | `"random"` | Server is sampled from the environment RNG every round. Use this for training to balance side exposure. |
 
 ## Action Space

--- a/src/pika_zoo/env/README.md
+++ b/src/pika_zoo/env/README.md
@@ -9,7 +9,7 @@ PettingZoo `ParallelEnv` for Pikachu Volleyball. Two agents (`player_1`, `player
 | Value | Behavior |
 |-------|----------|
 | `"winner"` | Scorer serves the next round. This is the default and matches the original game, so use it for evaluation. |
-| `"alternate"` | Server alternates every round. |
+| `"loser"` | The player who lost the previous point serves the next round. |
 | `"random"` | Server is sampled from the environment RNG every round. Use this for training to balance side exposure. |
 
 ## Action Space

--- a/src/pika_zoo/env/README.md
+++ b/src/pika_zoo/env/README.md
@@ -2,6 +2,16 @@
 
 PettingZoo `ParallelEnv` for Pikachu Volleyball. Two agents (`player_1`, `player_2`) act simultaneously each frame.
 
+## Serve Rule
+
+`PikachuVolleyballEnv(serve=...)` controls which side serves at the start of each round:
+
+| Value | Behavior |
+|-------|----------|
+| `"winner"` | Scorer serves the next round. This is the default and matches the original game, so use it for evaluation. |
+| `"alternate"` | Server alternates every round. |
+| `"random"` | Server is sampled from the environment RNG every round. Use this for training to balance side exposure. |
+
 ## Action Space
 
 18 discrete actions covering all combinations of 3 x-directions, 3 y-directions, and 2 power_hit states.

--- a/src/pika_zoo/env/pikachu_volleyball.py
+++ b/src/pika_zoo/env/pikachu_volleyball.py
@@ -21,7 +21,7 @@ from pika_zoo.engine.types import NoiseConfig, UserInput
 from pika_zoo.env.actions import NUM_ACTIONS, ActionConverter
 from pika_zoo.env.observations import build_observation, build_observation_space
 
-SERVE_RULES = {"winner", "alternate", "random"}
+SERVE_RULES = {"winner", "loser", "random"}
 
 
 class PikachuVolleyballEnv(ParallelEnv):
@@ -29,7 +29,7 @@ class PikachuVolleyballEnv(ParallelEnv):
 
     Args:
         winning_score: Score needed to win the game (default 15).
-        serve: Serve rule — "winner" (scorer serves), "alternate", or "random".
+        serve: Serve rule — "winner" (scorer serves), "loser", or "random".
         ai_policies: Dict mapping agent name to AIPolicy. When set, the env
             calls policy.compute_action() before physics step, overriding
             the action for that agent.
@@ -234,6 +234,7 @@ class PikachuVolleyballEnv(ParallelEnv):
             self._scores,
             metadata={
                 "noise": self.noise,
+                "serve": self.serve,
                 "p1_label": self._p1_label,
                 "p2_label": self._p2_label,
             },
@@ -302,12 +303,17 @@ class PikachuVolleyballEnv(ParallelEnv):
             "player_2": {**base, "events": events},
         }
 
-    def _get_serve(self, scorer_is_player2: bool = False) -> bool:
+    def _get_serve(self, scorer_is_player2: bool | None = None) -> bool:
         """Determine who serves. Returns True if player 2 serves."""
+        if scorer_is_player2 is None and self.serve != "random":
+            return False
         if self.serve == "winner":
+            assert scorer_is_player2 is not None
             return scorer_is_player2
+        elif self.serve == "loser":
+            assert scorer_is_player2 is not None
+            return not scorer_is_player2
         elif self.serve == "random":
             assert self._np_random is not None
             return bool(self._np_random.integers(0, 2))
-        else:  # alternate
-            return (self._scores[0] + self._scores[1]) % 2 == 1
+        raise AssertionError(f"Unhandled serve rule: {self.serve!r}")

--- a/src/pika_zoo/env/pikachu_volleyball.py
+++ b/src/pika_zoo/env/pikachu_volleyball.py
@@ -21,7 +21,7 @@ from pika_zoo.engine.types import NoiseConfig, UserInput
 from pika_zoo.env.actions import NUM_ACTIONS, ActionConverter
 from pika_zoo.env.observations import build_observation, build_observation_space
 
-SERVE_RULES = {"winner", "loser", "random"}
+SERVE_RULES = {"winner", "loser", "alternate", "random"}
 
 
 class PikachuVolleyballEnv(ParallelEnv):
@@ -29,7 +29,7 @@ class PikachuVolleyballEnv(ParallelEnv):
 
     Args:
         winning_score: Score needed to win the game (default 15).
-        serve: Serve rule — "winner" (scorer serves), "loser", or "random".
+        serve: Serve rule — "winner" (scorer serves), "loser", "alternate", or "random".
         ai_policies: Dict mapping agent name to AIPolicy. When set, the env
             calls policy.compute_action() before physics step, overriding
             the action for that agent.
@@ -305,15 +305,17 @@ class PikachuVolleyballEnv(ParallelEnv):
 
     def _get_serve(self, scorer_is_player2: bool | None = None) -> bool:
         """Determine who serves. Returns True if player 2 serves."""
-        if scorer_is_player2 is None and self.serve != "random":
-            return False
-        if self.serve == "winner":
-            assert scorer_is_player2 is not None
-            return scorer_is_player2
-        elif self.serve == "loser":
-            assert scorer_is_player2 is not None
-            return not scorer_is_player2
-        elif self.serve == "random":
+        if self.serve == "random":
             assert self._np_random is not None
             return bool(self._np_random.integers(0, 2))
+
+        if scorer_is_player2 is None:
+            return False
+
+        if self.serve == "winner":
+            return scorer_is_player2
+        elif self.serve == "loser":
+            return not scorer_is_player2
+        elif self.serve == "alternate":
+            return (self._scores[0] + self._scores[1]) % 2 == 1
         raise AssertionError(f"Unhandled serve rule: {self.serve!r}")

--- a/src/pika_zoo/env/pikachu_volleyball.py
+++ b/src/pika_zoo/env/pikachu_volleyball.py
@@ -21,6 +21,8 @@ from pika_zoo.engine.types import NoiseConfig, UserInput
 from pika_zoo.env.actions import NUM_ACTIONS, ActionConverter
 from pika_zoo.env.observations import build_observation, build_observation_space
 
+SERVE_RULES = {"winner", "alternate", "random"}
+
 
 class PikachuVolleyballEnv(ParallelEnv):
     """Pikachu Volleyball as a PettingZoo ParallelEnv.
@@ -54,6 +56,10 @@ class PikachuVolleyballEnv(ParallelEnv):
         p2_label: str = "",
     ) -> None:
         super().__init__()
+
+        if serve not in SERVE_RULES:
+            available = ", ".join(sorted(SERVE_RULES))
+            raise ValueError(f"Unknown serve rule: {serve!r}. Available: {available}")
 
         self.winning_score = winning_score
         self.serve = serve
@@ -97,9 +103,10 @@ class PikachuVolleyballEnv(ParallelEnv):
 
         self.agents = list(self.possible_agents)
 
+        self._scores = [0, 0]
+        self._is_player2_serve = self._get_serve()
         self._physics = PikaPhysics(self._np_random)
         self._physics.ball.initialize_for_new_round(self._is_player2_serve, noise=self.noise, rng=self._np_random)
-        self._scores = [0, 0]
         self._round_ended = False
         self._game_ended = False
 
@@ -179,7 +186,7 @@ class PikachuVolleyballEnv(ParallelEnv):
         if is_ball_touching_ground and not self._round_ended and not self._game_ended:
             if self._physics.ball.punch_effect_x < GROUND_HALF_WIDTH:
                 # Ball landed on player_1's side → player_2 scores
-                self._is_player2_serve = True
+                scorer_is_player2 = True
                 self._scores[1] += 1
                 rewards = {"player_1": -1.0, "player_2": 1.0}
                 if self._scores[1] >= self.winning_score:
@@ -189,7 +196,7 @@ class PikachuVolleyballEnv(ParallelEnv):
                     self._physics.player2.game_ended = True
             else:
                 # Ball landed on player_2's side → player_1 scores
-                self._is_player2_serve = False
+                scorer_is_player2 = False
                 self._scores[0] += 1
                 rewards = {"player_1": 1.0, "player_2": -1.0}
                 if self._scores[0] >= self.winning_score:
@@ -197,6 +204,7 @@ class PikachuVolleyballEnv(ParallelEnv):
                     self._physics.player1.is_winner = True
                     self._physics.player1.game_ended = True
                     self._physics.player2.game_ended = True
+            self._is_player2_serve = self._get_serve(scorer_is_player2)
             self._round_ended = True
 
         terminations = {agent: self._game_ended for agent in self.possible_agents}
@@ -294,10 +302,10 @@ class PikachuVolleyballEnv(ParallelEnv):
             "player_2": {**base, "events": events},
         }
 
-    def _get_serve(self) -> bool:
+    def _get_serve(self, scorer_is_player2: bool = False) -> bool:
         """Determine who serves. Returns True if player 2 serves."""
         if self.serve == "winner":
-            return self._is_player2_serve
+            return scorer_is_player2
         elif self.serve == "random":
             assert self._np_random is not None
             return bool(self._np_random.integers(0, 2))

--- a/src/pika_zoo/rendering/README.md
+++ b/src/pika_zoo/rendering/README.md
@@ -15,7 +15,8 @@ The renderer draws metadata overlays on top of the game:
 
 - **Score**: current score at top of screen
 - **Player labels**: names below each player
-- **Mode label**: "normal" or `noise(x=5, xv=3, yv=0)` at top center
+- **Serve label**: `serve: winner`, `serve: loser`, or `serve: random` at top center
+- **Noise label**: `noise: normal` or `noise: (x=5, xv=3, yv=0)` below the serve label
 
 ## Skins
 

--- a/src/pika_zoo/rendering/README.md
+++ b/src/pika_zoo/rendering/README.md
@@ -15,8 +15,8 @@ The renderer draws metadata overlays on top of the game:
 
 - **Score**: current score at top of screen
 - **Player labels**: names below each player
-- **Serve label**: `serve: winner`, `serve: loser`, `serve: alternate`, or `serve: random` at top center
-- **Noise label**: `noise: normal` or `noise: (x=5, xv=3, yv=0)` below the serve label
+- **Serve label**: `serve: winner`, `serve: loser`, `serve: alternate`, or `serve: random` at top center. The selected rule is blue.
+- **Noise label**: `noise: normal`, `noise: (x=5, xv=3, yv=0)`, or `noise: level1 (x=5, xv=3, yv=0)` below the serve label. The config tuple is blue.
 
 ## Skins
 

--- a/src/pika_zoo/rendering/README.md
+++ b/src/pika_zoo/rendering/README.md
@@ -15,7 +15,7 @@ The renderer draws metadata overlays on top of the game:
 
 - **Score**: current score at top of screen
 - **Player labels**: names below each player
-- **Serve label**: `serve: winner`, `serve: loser`, or `serve: random` at top center
+- **Serve label**: `serve: winner`, `serve: loser`, `serve: alternate`, or `serve: random` at top center
 - **Noise label**: `noise: normal` or `noise: (x=5, xv=3, yv=0)` below the serve label
 
 ## Skins

--- a/src/pika_zoo/rendering/renderer.py
+++ b/src/pika_zoo/rendering/renderer.py
@@ -275,18 +275,21 @@ class PygameRenderer:
     # ------------------------------------------------------------------
 
     def _draw_mode_label(self, metadata: dict[str, Any]) -> None:
-        """Draw mode label at top center — 'normal' or noise config details."""
+        """Draw serve and noise labels at top center."""
         noise = metadata.get("noise")
+        serve = metadata.get("serve", "winner")
         assert self._screen is not None
         if self._mode_font is None:
             pygame.font.init()
             self._mode_font = pygame.font.SysFont("monospace", 14, bold=True)
+
+        serve_label = f"serve: {serve}"
         if noise is not None:
-            label = f"noise(x={noise.x_range}, xv={noise.x_velocity_range}, yv={noise.y_velocity_range})"
-            color = (0, 0, 255)
+            noise_label = f"noise: (x={noise.x_range}, xv={noise.x_velocity_range}, yv={noise.y_velocity_range})"
         else:
-            label = "normal"
-            color = (0, 0, 0)
-        rendered = self._mode_font.render(label, True, color)
-        x = SCREEN_WIDTH // 2 - rendered.get_width() // 2
-        self._screen.blit(rendered, (x, 10))
+            noise_label = "noise: normal"
+
+        for label, y in [(serve_label, 8), (noise_label, 24)]:
+            rendered = self._mode_font.render(label, True, (0, 0, 0))
+            x = SCREEN_WIDTH // 2 - rendered.get_width() // 2
+            self._screen.blit(rendered, (x, y))

--- a/src/pika_zoo/rendering/renderer.py
+++ b/src/pika_zoo/rendering/renderer.py
@@ -283,13 +283,26 @@ class PygameRenderer:
             pygame.font.init()
             self._mode_font = pygame.font.SysFont("monospace", 14, bold=True)
 
-        serve_label = f"serve: {serve}"
+        blue = (0, 0, 255)
+        black = (0, 0, 0)
         if noise is not None:
-            noise_label = f"noise: (x={noise.x_range}, xv={noise.x_velocity_range}, yv={noise.y_velocity_range})"
+            noise_config = f"(x={noise.x_range}, xv={noise.x_velocity_range}, yv={noise.y_velocity_range})"
+            noise_name = f"{noise.name} " if noise.name else ""
+            noise_segments = [("noise: ", black), (noise_name, black), (noise_config, blue)]
         else:
-            noise_label = "noise: normal"
+            noise_segments = [("noise: normal", black)]
 
-        for label, y in [(serve_label, 8), (noise_label, 24)]:
-            rendered = self._mode_font.render(label, True, (0, 0, 0))
-            x = SCREEN_WIDTH // 2 - rendered.get_width() // 2
-            self._screen.blit(rendered, (x, y))
+        self._draw_centered_text_segments([("serve: ", black), (str(serve), blue)], y=8)
+        self._draw_centered_text_segments(noise_segments, y=24)
+
+    def _draw_centered_text_segments(self, segments: list[tuple[str, tuple[int, int, int]]], y: int) -> None:
+        """Draw same-baseline text segments centered as one line."""
+        assert self._screen is not None
+        assert self._mode_font is not None
+
+        rendered_segments = [(self._mode_font.render(text, True, color), text) for text, color in segments if text]
+        total_width = sum(surface.get_width() for surface, _ in rendered_segments)
+        x = SCREEN_WIDTH // 2 - total_width // 2
+        for surface, _ in rendered_segments:
+            self._screen.blit(surface, (x, y))
+            x += surface.get_width()

--- a/src/pika_zoo/scripts/README.md
+++ b/src/pika_zoo/scripts/README.md
@@ -47,6 +47,7 @@ sampling experiments; the sampling sequence is controlled by `--seed`.
 |------|---------|-------------|
 | `--p1`, `--p2` | `builtin` | Player spec: `"builtin"`, `"duckll"`, `"duckll:N"`, `"random"`, `"stone"`, `"human"`, model path (.zip), or model directory |
 | `--winning-score` | 15 | Score to win |
+| `--serve` | `winner` | Serve rule: `winner`, `loser`, or `random` |
 | `--seed` | None | Random seed |
 | `--fps` | 25 | Frame rate |
 | `--no-render` | off | Disable pygame window |

--- a/src/pika_zoo/scripts/README.md
+++ b/src/pika_zoo/scripts/README.md
@@ -56,6 +56,7 @@ sampling experiments; the sampling sequence is controlled by `--seed`.
 | `--noise-x N` | None | Ball x position noise ±N pixels |
 | `--noise-x-vel N` | None | Ball x velocity noise ±N |
 | `--noise-y-vel N` | None | Ball y velocity noise ±N |
+| `--noise-name NAME` | None | Display name for the noise config |
 | `--p1-skin`, `--p2-skin` | auto | Override pikachu skin (azure, gray, lime, orange, white, yellow) |
 | `--p1-label`, `--p2-label` | auto | Override display label |
 | `--p1-keymap`, `--p2-keymap` | P1=original, P2=arrows | Keyboard layout preset |

--- a/src/pika_zoo/scripts/README.md
+++ b/src/pika_zoo/scripts/README.md
@@ -47,7 +47,7 @@ sampling experiments; the sampling sequence is controlled by `--seed`.
 |------|---------|-------------|
 | `--p1`, `--p2` | `builtin` | Player spec: `"builtin"`, `"duckll"`, `"duckll:N"`, `"random"`, `"stone"`, `"human"`, model path (.zip), or model directory |
 | `--winning-score` | 15 | Score to win |
-| `--serve` | `winner` | Serve rule: `winner`, `loser`, or `random` |
+| `--serve` | `winner` | Serve rule: `winner`, `loser`, `alternate`, or `random` |
 | `--seed` | None | Random seed |
 | `--fps` | 25 | Frame rate |
 | `--no-render` | off | Disable pygame window |

--- a/src/pika_zoo/scripts/play.py
+++ b/src/pika_zoo/scripts/play.py
@@ -50,7 +50,7 @@ def play(
         p1: Player 1 — AI name, "human", or model path.
         p2: Player 2 — AI name, "human", or model path.
         winning_score: Score to win.
-        serve: Serve rule: "winner", "loser", or "random".
+        serve: Serve rule: "winner", "loser", "alternate", or "random".
         seed: Random seed.
         fps: Frame rate (for render and/or recording).
         render: Show pygame window.
@@ -281,8 +281,8 @@ def main(argv: list[str] | None = None) -> None:
         "--serve",
         type=str,
         default="winner",
-        choices=["winner", "loser", "random"],
-        help="Serve rule: winner, loser, or random (default: winner)",
+        choices=["winner", "loser", "alternate", "random"],
+        help="Serve rule: winner, loser, alternate, or random (default: winner)",
     )
     parser.add_argument("--seed", type=int, default=None, help="Random seed")
     parser.add_argument(

--- a/src/pika_zoo/scripts/play.py
+++ b/src/pika_zoo/scripts/play.py
@@ -265,12 +265,13 @@ def _load_model_dir(dir_path: Path) -> tuple[Path, dict]:
 
 
 def _build_noise(args: argparse.Namespace) -> NoiseConfig | None:
-    if args.noise_x is None and args.noise_x_vel is None and args.noise_y_vel is None:
+    if args.noise_x is None and args.noise_x_vel is None and args.noise_y_vel is None and args.noise_name is None:
         return None
     return NoiseConfig(
         x_range=args.noise_x or 0,
         x_velocity_range=args.noise_x_vel or 0,
         y_velocity_range=args.noise_y_vel or 0,
+        name=args.noise_name,
     )
 
 
@@ -304,6 +305,13 @@ def main(argv: list[str] | None = None) -> None:
     parser.add_argument("--noise-x", type=int, default=None, metavar="N", help="Ball x position noise ±N pixels")
     parser.add_argument("--noise-x-vel", type=int, default=None, metavar="N", help="Ball x velocity noise ±N")
     parser.add_argument("--noise-y-vel", type=int, default=None, metavar="N", help="Ball y velocity noise ±N")
+    parser.add_argument(
+        "--noise-name",
+        type=str,
+        default=None,
+        metavar="NAME",
+        help="Display name for the noise config",
+    )
     parser.add_argument(
         "--p1-skin",
         type=str,

--- a/src/pika_zoo/scripts/play.py
+++ b/src/pika_zoo/scripts/play.py
@@ -30,6 +30,7 @@ def play(
     p1: str = "builtin",
     p2: str = "builtin",
     winning_score: int = 15,
+    serve: str = "winner",
     seed: int | None = None,
     fps: int = 25,
     render: bool = True,
@@ -49,6 +50,7 @@ def play(
         p1: Player 1 — AI name, "human", or model path.
         p2: Player 2 — AI name, "human", or model path.
         winning_score: Score to win.
+        serve: Serve rule: "winner", "loser", or "random".
         seed: Random seed.
         fps: Frame rate (for render and/or recording).
         render: Show pygame window.
@@ -136,6 +138,7 @@ def play(
         render_mode=render_mode,
         ai_policies=ai_policies,
         winning_score=winning_score,
+        serve=serve,
         noise=noise,
         p1_skin=resolved_p1_skin,
         p2_skin=resolved_p2_skin,
@@ -274,6 +277,13 @@ def _build_noise(args: argparse.Namespace) -> NoiseConfig | None:
 def main(argv: list[str] | None = None) -> None:
     parser = argparse.ArgumentParser(description="Play, watch, or record Pikachu Volleyball")
     parser.add_argument("--winning-score", type=int, default=15, help="Score to win (default: 15)")
+    parser.add_argument(
+        "--serve",
+        type=str,
+        default="winner",
+        choices=["winner", "loser", "random"],
+        help="Serve rule: winner, loser, or random (default: winner)",
+    )
     parser.add_argument("--seed", type=int, default=None, help="Random seed")
     parser.add_argument(
         "--p1",
@@ -316,6 +326,7 @@ def main(argv: list[str] | None = None) -> None:
         p1=args.p1,
         p2=args.p2,
         winning_score=args.winning_score,
+        serve=args.serve,
         seed=args.seed,
         fps=args.fps,
         render=not args.no_render,

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -11,7 +11,7 @@ from pika_zoo.engine.constants import (
 )
 from pika_zoo.engine.physics import Ball, PikaPhysics, Player
 from pika_zoo.engine.rand import rand
-from pika_zoo.engine.types import PlayerState, UserInput
+from pika_zoo.engine.types import NoiseConfig, PlayerState, UserInput
 
 
 class TestConstants:
@@ -49,6 +49,16 @@ class TestUserInput:
         assert ui.x_direction == 0
         assert ui.y_direction == 0
         assert ui.power_hit == 0
+
+
+class TestNoiseConfig:
+    def test_optional_name(self):
+        noise = NoiseConfig(x_range=5, x_velocity_range=2, y_velocity_range=1, name="level1")
+        assert noise.name == "level1"
+
+    def test_name_defaults_to_none(self):
+        noise = NoiseConfig(x_range=5, x_velocity_range=2, y_velocity_range=1)
+        assert noise.name is None
 
 
 class TestPlayerState:

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -55,6 +55,20 @@ class TestActionConverter:
 
 
 class TestPikachuVolleyballEnv:
+    def _start_next_round(self, e):
+        actions = {"player_1": 0, "player_2": 0}
+        for _ in range(3000):
+            obs, rewards, terms, truncs, infos = e.step(actions)
+            if infos["player_1"]["round_ended"]:
+                assert not any(terms.values())
+                break
+        else:
+            pytest.fail("Round should end within 3000 frames")
+
+        obs, rewards, terms, truncs, infos = e.step(actions)
+        assert not infos["player_1"]["round_ended"]
+        return obs
+
     def test_create_env(self):
         e = env()
         assert e.possible_agents == ["player_1", "player_2"]
@@ -72,6 +86,34 @@ class TestPikachuVolleyballEnv:
         e.reset(seed=42)
         assert e.action_space("player_1").n == NUM_ACTIONS
         assert e.action_space("player_2").n == NUM_ACTIONS
+
+    def test_invalid_serve_rule(self):
+        with pytest.raises(ValueError, match="Unknown serve rule"):
+            env(serve="coinflip")
+
+    def test_alternate_serve_rule_switches_sides_each_round(self):
+        e = env(winning_score=4, serve="alternate")
+        obs, _ = e.reset(seed=42)
+        assert obs["player_1"][26] == pytest.approx(56.0)
+
+        obs = self._start_next_round(e)
+        assert obs["player_1"][26] == pytest.approx(376.0)
+
+        obs = self._start_next_round(e)
+        assert obs["player_1"][26] == pytest.approx(56.0)
+
+    def test_random_serve_rule_is_seeded(self):
+        def server_sequence(seed):
+            e = env(winning_score=6, serve="random")
+            obs, _ = e.reset(seed=seed)
+            sequence = [obs["player_1"][26]]
+            for _ in range(4):
+                obs = self._start_next_round(e)
+                sequence.append(obs["player_1"][26])
+            return sequence
+
+        assert server_sequence(42) == server_sequence(42)
+        assert server_sequence(42) != server_sequence(43)
 
     def test_observation_space(self):
         e = env()

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -105,6 +105,17 @@ class TestPikachuVolleyballEnv:
         assert scores == [1, 1]
         assert obs["player_1"][26] == pytest.approx(56.0)
 
+    def test_alternate_serve_rule_switches_sides_each_round(self):
+        e = env(winning_score=4, serve="alternate")
+        obs, _ = e.reset(seed=42)
+        assert obs["player_1"][26] == pytest.approx(56.0)
+
+        obs, _ = self._start_next_round(e)
+        assert obs["player_1"][26] == pytest.approx(376.0)
+
+        obs, _ = self._start_next_round(e)
+        assert obs["player_1"][26] == pytest.approx(56.0)
+
     def test_random_serve_rule_is_seeded(self):
         def server_sequence(seed):
             e = env(winning_score=6, serve="random")

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -61,13 +61,14 @@ class TestPikachuVolleyballEnv:
             obs, rewards, terms, truncs, infos = e.step(actions)
             if infos["player_1"]["round_ended"]:
                 assert not any(terms.values())
+                scores = infos["player_1"]["scores"]
                 break
         else:
             pytest.fail("Round should end within 3000 frames")
 
         obs, rewards, terms, truncs, infos = e.step(actions)
         assert not infos["player_1"]["round_ended"]
-        return obs
+        return obs, scores
 
     def test_create_env(self):
         e = env()
@@ -91,15 +92,17 @@ class TestPikachuVolleyballEnv:
         with pytest.raises(ValueError, match="Unknown serve rule"):
             env(serve="coinflip")
 
-    def test_alternate_serve_rule_switches_sides_each_round(self):
-        e = env(winning_score=4, serve="alternate")
+    def test_loser_serve_rule_gives_next_serve_to_non_scorer(self):
+        e = env(winning_score=4, serve="loser")
         obs, _ = e.reset(seed=42)
         assert obs["player_1"][26] == pytest.approx(56.0)
 
-        obs = self._start_next_round(e)
+        obs, scores = self._start_next_round(e)
+        assert scores == [1, 0]
         assert obs["player_1"][26] == pytest.approx(376.0)
 
-        obs = self._start_next_round(e)
+        obs, scores = self._start_next_round(e)
+        assert scores == [1, 1]
         assert obs["player_1"][26] == pytest.approx(56.0)
 
     def test_random_serve_rule_is_seeded(self):
@@ -108,7 +111,7 @@ class TestPikachuVolleyballEnv:
             obs, _ = e.reset(seed=seed)
             sequence = [obs["player_1"][26]]
             for _ in range(4):
-                obs = self._start_next_round(e)
+                obs, _ = self._start_next_round(e)
                 sequence.append(obs["player_1"][26])
             return sequence
 


### PR DESCRIPTION
## Summary
- Honor serve rules across rounds and support winner, loser, alternate, and random modes
- Add serve/noise metadata to rendering with colored option/config labels
- Add optional display name to NoiseConfig and expose --serve / --noise-name in play

## Test Plan
- uv run ruff check .
- uv run pytest -q
- Headless render smoke for winner/loser/alternate/random serve modes