### PR TITLE
chore(release): bump version to 1.6.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pika-zoo"
-version = "1.6.0"
+version = "1.6.1"
 description = "Python port of Pikachu Volleyball as an RL environment, with various utilities"
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -138,7 +138,7 @@ wheels = [
 
 [[package]]
 name = "pika-zoo"
-version = "1.6.0"
+version = "1.6.1"
 source = { editable = "." }
 dependencies = [
     { name = "gymnasium" },


### PR DESCRIPTION
## Summary
- Bump package version from 1.6.0 to 1.6.1
- Sync uv.lock editable package version

## Test Plan
- uv run ruff check .
- uv run pytest -q